### PR TITLE
rest -> drop

### DIFF
--- a/src/dixon.jl
+++ b/src/dixon.jl
@@ -20,7 +20,7 @@ end
 function common_esd(Ns, F::Type{<:FiniteFields.GF})
     @assert !isempty(Ns)
     esd = EigenSpaceDecomposition(F.(first(Ns)))
-    for N in Iterators.rest(Ns, 2)
+    for N in Iterators.drop(Ns, 1)
         esd = refine(esd, F.(N))
         @debug N esd.eigspace_ptrs
         isdiag(esd) && return esd

--- a/src/dixon.jl
+++ b/src/dixon.jl
@@ -18,9 +18,10 @@ function dixon_prime(ordG::Integer, exponent::Integer)
 end
 
 function common_esd(Ns, F::Type{<:FiniteFields.GF})
-    @assert !isempty(Ns)
-    esd = EigenSpaceDecomposition(F.(first(Ns)))
-    for N in Iterators.drop(Ns, 1)
+    itr = iterate(Ns)
+    @assert itr !== nothing
+    esd = EigenSpaceDecomposition(F.(first(itr)))
+    for N in Iterators.rest(Ns, last(itr))
         esd = refine(esd, F.(N))
         @debug N esd.eigspace_ptrs
         isdiag(esd) && return esd


### PR DESCRIPTION
The current implementation relies on the state of the iterator of `Vector` which is an issue as it may change and we don't have `::Vector` in the signature of the method