### PR TITLE
Return multiplicity info in isotypical_basis

### DIFF
--- a/src/projections.jl
+++ b/src/projections.jl
@@ -169,16 +169,17 @@ function symmetry_adapted_basis(::Type{T}, G::Group, basis, action) where {T}
 end
 
 struct SemisimpleSummand{T}
-    constituent::T
+    basis::T
     multiplicity::Int
 end
 
-Base.Matrix(b::SemisimpleSummand) = Matrix{eltype(b.basis)}(b.basis)
-Base.Matrix{T}(b::SemisimpleSummand) where T = convert(Matrix{T}, b.basis)
+basis(b::SemisimpleSummand) = b.basis
+Base.convert(::Type{M}, b::SemisimpleSummand) where M<:AbstractMatrix = convert(M, basis(b))
 
 multiplicity(b::SemisimpleSummand) = b.multiplicity
+
 function degree(b::SemisimpleSummand)
-    d,r = divrem(size(b.basis, 1), b.multiplicity)
+    d,r = divrem(size(basis(b), 1), multiplicity(b))
     @assert iszero(r)
     return d
 end
@@ -201,7 +202,6 @@ function symmetry_adapted_basis(
     dot(multiplicities, degrees) == degree(ψ) ||
         @warn "chars do not constitute a complete basis for action:
         $(dot(multiplicities, degrees)) ≠ $(degree(ψ))"
-    constituents = [χ for (χ, m) in zip(real_chars, multiplicities) if m ≠ 0]
 
     return [
         SemisimpleSummand(isotypical_basis(χ), m) for

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -171,9 +171,17 @@ end
 struct SemisimpleSummand{T}
     constituent::T
     multiplicity::Int
-    degree::Int
 end
-Base.size(b::SemisimpleSummand, args...) = size(b.constituent, args...)
+
+Base.Matrix(b::SemisimpleSummand) = Matrix{eltype(b.basis)}(b.basis)
+Base.Matrix{T}(b::SemisimpleSummand) where T = convert(Matrix{T}, b.basis)
+
+multiplicity(b::SemisimpleSummand) = b.multiplicity
+function degree(b::SemisimpleSummand)
+    d,r = divrem(size(b.basis, 1), b.multiplicity)
+    @assert iszero(r)
+    return d
+end
 
 function symmetry_adapted_basis(
     ::Type{T},
@@ -196,7 +204,7 @@ function symmetry_adapted_basis(
     constituents = [χ for (χ, m) in zip(real_chars, multiplicities) if m ≠ 0]
 
     return [
-        SemisimpleSummand(isotypical_basis(χ), m, d) for
-        (χ, m, d) in zip(real_chars, multiplicities, degrees) if m ≠ 0
+        SemisimpleSummand(isotypical_basis(χ), m) for
+        (χ, m) in zip(real_chars, multiplicities) if m ≠ 0
     ]
 end

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -168,6 +168,13 @@ function symmetry_adapted_basis(::Type{T}, G::Group, basis, action) where {T}
     return symmetry_adapted_basis(T, chars_ext)
 end
 
+struct IsotypicalBasisElement{T}
+    constituent::T
+    multiplicity::Int
+    degree::Int
+end
+Base.size(b::IsotypicalBasisElement, args...) = size(b.constituent, args...)
+
 function symmetry_adapted_basis(
     ::Type{T},
     chars::AbstractVector{<:AbstractClassFunction},
@@ -188,5 +195,8 @@ function symmetry_adapted_basis(
         $(dot(multiplicities, degrees)) ≠ $(degree(ψ))"
     constituents = [χ for (χ, m) in zip(real_chars, multiplicities) if m ≠ 0]
 
-    return isotypical_basis.(constituents)
+    return [
+        IsotypicalBasisElement(isotypical_basis(χ), m, d) for
+        (χ, m, d) in zip(real_chars, multiplicities, degrees) if m ≠ 0
+    ]
 end

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -168,12 +168,12 @@ function symmetry_adapted_basis(::Type{T}, G::Group, basis, action) where {T}
     return symmetry_adapted_basis(T, chars_ext)
 end
 
-struct IsotypicalBasisElement{T}
+struct SemisimpleSummand{T}
     constituent::T
     multiplicity::Int
     degree::Int
 end
-Base.size(b::IsotypicalBasisElement, args...) = size(b.constituent, args...)
+Base.size(b::SemisimpleSummand, args...) = size(b.constituent, args...)
 
 function symmetry_adapted_basis(
     ::Type{T},
@@ -196,7 +196,7 @@ function symmetry_adapted_basis(
     constituents = [χ for (χ, m) in zip(real_chars, multiplicities) if m ≠ 0]
 
     return [
-        IsotypicalBasisElement(isotypical_basis(χ), m, d) for
+        SemisimpleSummand(isotypical_basis(χ), m, d) for
         (χ, m, d) in zip(real_chars, multiplicities, degrees) if m ≠ 0
     ]
 end

--- a/test/action_linear.jl
+++ b/test/action_linear.jl
@@ -55,6 +55,6 @@ end
         @test M^2 ≈ one(M)
 
         B = SymbolicWedderburn.symmetry_adapted_basis(G, basis, MyAction());
-        @test sum(first∘size, B) == length(basis)
+        @test sum(first ∘ size ∘ SymbolicWedderburn.basis, B) == length(basis)
     end
 end

--- a/test/action_permutation.jl
+++ b/test/action_permutation.jl
@@ -39,7 +39,7 @@ my_action(w::Word, g) = SymbolicWedderburn.action(OnLetters(), g, w)
     G = PermGroup(perm"(1,2,3)",perm"(1,2)") # G acts on words permuting letters
     sa_basis = symmetry_adapted_basis(G, words, OnLetters())
 
-    @test sa_basis isa Vector{<:SymbolicWedderburn.IsotypicalBasisElement{<:Matrix{<:SymbolicWedderburn.Cyclotomic}}}
+    @test sa_basis isa Vector{<:SymbolicWedderburn.SemisimpleSummand{<:Matrix{<:SymbolicWedderburn.Cyclotomic}}}
     @test [Matrix{Int}(b.constituent) for b in sa_basis] isa Vector{Matrix{Int}}
     @test sum(first∘size, sa_basis) == length(words)
 end

--- a/test/action_permutation.jl
+++ b/test/action_permutation.jl
@@ -40,6 +40,7 @@ my_action(w::Word, g) = SymbolicWedderburn.action(OnLetters(), g, w)
     sa_basis = symmetry_adapted_basis(G, words, OnLetters())
 
     @test sa_basis isa Vector{<:SymbolicWedderburn.SemisimpleSummand{<:Matrix{<:SymbolicWedderburn.Cyclotomic}}}
-    @test [Matrix{Int}(b.constituent) for b in sa_basis] isa Vector{Matrix{Int}}
-    @test sum(first∘size, sa_basis) == length(words)
+    @test [convert(Matrix{Int}, b) for b in sa_basis] isa Vector{Matrix{Int}}
+    @test [convert(Matrix{Float64}, b) for b in sa_basis] isa Vector{Matrix{Float64}}
+    @test sum(first ∘ size ∘ SymbolicWedderburn.basis, sa_basis) == length(words)
 end

--- a/test/action_permutation.jl
+++ b/test/action_permutation.jl
@@ -39,7 +39,7 @@ my_action(w::Word, g) = SymbolicWedderburn.action(OnLetters(), g, w)
     G = PermGroup(perm"(1,2,3)",perm"(1,2)") # G acts on words permuting letters
     sa_basis = symmetry_adapted_basis(G, words, OnLetters())
 
-    @test sa_basis isa Vector{<:Matrix{<:SymbolicWedderburn.Cyclotomic}}
-    @test Matrix{Int}.(sa_basis) isa Vector{Matrix{Int}}
+    @test sa_basis isa Vector{<:SymbolicWedderburn.IsotypicalBasisElement{<:Matrix{<:SymbolicWedderburn.Cyclotomic}}}
+    @test [Matrix{Int}(b.constituent) for b in sa_basis] isa Vector{Matrix{Int}}
     @test sum(first∘size, sa_basis) == length(words)
 end

--- a/test/projections.jl
+++ b/test/projections.jl
@@ -99,6 +99,8 @@ end
 
             basis = symmetry_adapted_basis(T, G)
 
+            @test dot(SymbolicWedderburn.degree.(basis), SymbolicWedderburn.multiplicity.(basis)) == degree(G)
+
             # (ord,n) in (,) && continue
 
             # @test all(rank(float.(b)) == size(b, 1) for b in basis)

--- a/test/projections.jl
+++ b/test/projections.jl
@@ -50,27 +50,27 @@ end
 @testset "Symmetry adapted basis" begin
     G = PermGroup([perm"(1,2,3,4)"])
     basis = symmetry_adapted_basis(Complex{Rational{Int}}, G)
-    @test sum(first ∘ size, basis) == degree(G)
+    @test sum(first ∘ size ∘ SymbolicWedderburn.basis, basis) == degree(G)
 
     G = PermGroup([perm"(1,2,3,4)", perm"(1,2)"])
     basis = symmetry_adapted_basis(ComplexF64, G)
-    @test sum(first ∘ size, basis) == degree(G)
+    @test sum(first ∘ size ∘ SymbolicWedderburn.basis, basis) == degree(G)
 
     G = PermGroup([perm"(1,2,3)", perm"(2,3,4)"])
     basis = symmetry_adapted_basis(ComplexF64, G)
-    @test sum(first ∘ size, basis) == degree(G)
+    @test sum(first ∘ size ∘ SymbolicWedderburn.basis, basis) == degree(G)
 
     G = PermGroup([perm"(1,2,3,4)"])
     basis = symmetry_adapted_basis(Rational{Int}, G)
-    @test sum(first ∘ size, basis) == degree(G)
+    @test sum(first ∘ size ∘ SymbolicWedderburn.basis, basis) == degree(G)
 
     G = PermGroup([perm"(1,2,3,4)", perm"(1,2)"])
     basis = symmetry_adapted_basis(Float64, G)
-    @test sum(first ∘ size, basis) == degree(G)
+    @test sum(first ∘ size ∘ SymbolicWedderburn.basis, basis) == degree(G)
 
     G = PermGroup([perm"(1,2,3)", perm"(2,3,4)"])
     basis = symmetry_adapted_basis(G)
-    @test sum(first ∘ size, basis) == degree(G)
+    @test sum(first ∘ size ∘ SymbolicWedderburn.basis, basis) == degree(G)
 
     @time for ord = 2:16 # to keep running time reasonable
         @testset "SmallGroup($ord, $n)" for (n, G) in enumerate(SmallPermGroups[ord])
@@ -80,11 +80,14 @@ end
 
             (ord,n) in ((11, 1), (13, 1)) && continue
 
-            @test all(rank(float.(b.constituent)) == size(b, 1) for b in basis)
+            @test all(basis) do b
+                B = convert(Matrix{Float64}, b)
+                rank(B) == size(B, 1)
+            end
 
-            @test sum(first ∘ size, basis) == degree(G)
+            @test sum(first ∘ size ∘ SymbolicWedderburn.basis, basis) == degree(G)
             basisC = symmetry_adapted_basis(Complex{T}, G)
-            @test sum(first ∘ size, basisC) == degree(G)
+            @test sum(first ∘ size ∘ SymbolicWedderburn.basis, basisC) == degree(G)
         end
     end
 
@@ -101,13 +104,9 @@ end
 
             @test dot(SymbolicWedderburn.degree.(basis), SymbolicWedderburn.multiplicity.(basis)) == degree(G)
 
-            # (ord,n) in (,) && continue
-
-            # @test all(rank(float.(b)) == size(b, 1) for b in basis)
-
-            @test sum(first ∘ size, basis) == degree(G)
+            @test sum(first ∘ size ∘ SymbolicWedderburn.basis, basis) == degree(G)
             basisC = symmetry_adapted_basis(Complex{T}, G)
-            @test sum(first ∘ size, basisC) == degree(G)
+            @test sum(first ∘ size ∘ SymbolicWedderburn.basis, basisC) == degree(G)
         end
     end
 end

--- a/test/projections.jl
+++ b/test/projections.jl
@@ -80,7 +80,7 @@ end
 
             (ord,n) in ((11, 1), (13, 1)) && continue
 
-            @test all(rank(float.(b)) == size(b, 1) for b in basis)
+            @test all(rank(float.(b.constituent)) == size(b, 1) for b in basis)
 
             @test sum(first ∘ size, basis) == degree(G)
             basisC = symmetry_adapted_basis(Complex{T}, G)


### PR DESCRIPTION
SumOfSquares need this info to further reduce in case the degree is not 1. Alternatively, we could return three vectors of the same size but a vector of `struct` seems cleaner