### PR TITLE
Fix/symbolic invariant vectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StarAlgebras = "0c0c59c1-dc5f-42e9-9a8b-b5dc384a6cd1"
 
 [compat]
-Cyclotomics = "0.2.3"
+Cyclotomics = "0.3"
 GroupsCore = "0.4"
 PermutationGroups = "0.3.1"
 Primes = "0.4, 0.5"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "tweisser <tillmann.weisser@web.d
 version = "0.3.0"
 
 [deps]
+Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 Cyclotomics = "da8f5974-afbb-4dc8-91d8-516d5257c83b"
 GroupsCore = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ GroupsCore = "0.4"
 PermutationGroups = "0.3.1"
 Primes = "0.4, 0.5"
 StarAlgebras = "0.1.5"
-julia = "1"
+julia = "1.6"
 
 [extras]
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicWedderburn"
 uuid = "858aa9a9-4c7c-4c62-b466-2421203962a2"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "tweisser <tillmann.weisser@web.de>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Cyclotomics = "da8f5974-afbb-4dc8-91d8-516d5257c83b"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Marek Kaluba <kalmar@amu.edu.pl>", "tweisser <tillmann.weisser@web.d
 version = "0.3.0"
 
 [deps]
-Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 Cyclotomics = "da8f5974-afbb-4dc8-91d8-516d5257c83b"
 GroupsCore = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.7.0"
+julia_version = "1.7.1"
 manifest_format = "2.0"
 
 [[deps.AbstractAlgebra]]
@@ -44,9 +44,9 @@ version = "0.5.1"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "4c26b4e9e91ca528ea212927326ece5918a04b47"
+git-tree-sha1 = "d711603452231bad418bd5e0c91f1abd650cba71"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.11.2"
+version = "1.11.3"
 
 [[deps.ChangesOfVariables]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
@@ -66,11 +66,6 @@ git-tree-sha1 = "ded953804d019afa9a3f98981d99b33e3db7b6da"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
 version = "0.7.0"
 
-[[deps.Combinatorics]]
-git-tree-sha1 = "08c8b6831dc00bfea825826be0bc8336fc369860"
-uuid = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
-version = "1.0.2"
-
 [[deps.CommonSubexpressions]]
 deps = ["MacroTools", "Test"]
 git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
@@ -89,15 +84,15 @@ uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 
 [[deps.ComplexOptInterface]]
 deps = ["MathOptInterface", "MutableArithmetics"]
-git-tree-sha1 = "4cd32b867e7d1f8b522461cd9312d380dfec0bb3"
+git-tree-sha1 = "343cdb56037209f6be1f4f967f23c65a279d1a63"
 uuid = "25c3070e-1275-41b5-afef-2f982c87090a"
-version = "0.0.3"
+version = "0.0.2"
 
 [[deps.Cyclotomics]]
 deps = ["LRUCache", "Memoize", "Primes", "SparseArrays", "Test"]
-git-tree-sha1 = "aff368c5b38052cc10140d6c3cdcd2b5862903f8"
+git-tree-sha1 = "0a47d604b0940694d8cb3decb94e36a58401e386"
 uuid = "da8f5974-afbb-4dc8-91d8-516d5257c83b"
-version = "0.2.3"
+version = "0.3.1"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
@@ -141,9 +136,9 @@ uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
 [[deps.DynamicPolynomials]]
 deps = ["DataStructures", "Future", "LinearAlgebra", "MultivariatePolynomials", "MutableArithmetics", "Pkg", "Reexport", "Test"]
-git-tree-sha1 = "585de0d658506cf0fe5808026edff662bef5bf03"
+git-tree-sha1 = "1b4665a7e303eaa7e03542cfaef0730cb056cb00"
 uuid = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
-version = "0.4.1"
+version = "0.3.21"
 
 [[deps.ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
@@ -160,6 +155,18 @@ deps = ["Markdown", "Random"]
 git-tree-sha1 = "9e1a5e9f3b81ad6a5c613d181664a0efc6fe6dd7"
 uuid = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"
 version = "0.4.0"
+
+[[deps.HTTP]]
+deps = ["Base64", "Dates", "IniFile", "Logging", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
+git-tree-sha1 = "0fa77022fe4b511826b39c894c90daf5fce3334a"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "0.9.17"
+
+[[deps.IniFile]]
+deps = ["Test"]
+git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
+uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
+version = "0.5.0"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
@@ -188,11 +195,17 @@ git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.2"
 
+[[deps.JSONSchema]]
+deps = ["HTTP", "JSON", "URIs"]
+git-tree-sha1 = "2f49f7f86762a0fbbeef84912265a1ae61c4ef80"
+uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
+version = "0.3.4"
+
 [[deps.JuMP]]
 deps = ["Calculus", "DataStructures", "ForwardDiff", "JSON", "LinearAlgebra", "MathOptInterface", "MutableArithmetics", "NaNMath", "Printf", "Random", "SparseArrays", "SpecialFunctions", "Statistics"]
-git-tree-sha1 = "de9c69c0862be0e11afe5d4aa3426af1d7ecac2c"
+git-tree-sha1 = "4358b7cbf2db36596bdbbe3becc6b9d87e4eb8f5"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
-version = "0.22.1"
+version = "0.21.10"
 
 [[deps.LRUCache]]
 git-tree-sha1 = "d64a0aff6691612ab9fb0117b0995270871c5dfc"
@@ -224,9 +237,9 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.LogExpFunctions]]
 deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "be9eef9f9d78cecb6f262f3c10da151a6c5ab827"
+git-tree-sha1 = "e5718a00af0ab9756305a0392832c8952c7426c1"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.5"
+version = "0.3.6"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -242,10 +255,22 @@ deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[deps.MathOptInterface]]
-deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "JSON", "LinearAlgebra", "MutableArithmetics", "OrderedCollections", "Printf", "SparseArrays", "Test", "Unicode"]
-git-tree-sha1 = "92b7de61ecb616562fd2501334f729cc9db2a9a6"
+deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "JSON", "JSONSchema", "LinearAlgebra", "MutableArithmetics", "OrderedCollections", "SparseArrays", "Test", "Unicode"]
+git-tree-sha1 = "575644e3c05b258250bb599e57cf73bbf1062901"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "0.10.6"
+version = "0.9.22"
+
+[[deps.MathProgBase]]
+deps = ["LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "9abbe463a1e9fc507f12a69e7f29346c2cdc472c"
+uuid = "fdba3010-5040-5b88-9595-932c9decdf73"
+version = "0.7.8"
+
+[[deps.MbedTLS]]
+deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
+git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "1.0.3"
 
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -265,32 +290,32 @@ uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 
 [[deps.MultivariateBases]]
 deps = ["MultivariatePolynomials", "MutableArithmetics"]
-git-tree-sha1 = "7759e4f8151b41b08be48ba6b7941c028d0cdc4c"
+git-tree-sha1 = "7537fef91585f2ff805bbdb1f903ad982f104149"
 uuid = "be282fd4-ad43-11e9-1d11-8bd9d7e43378"
-version = "0.1.4"
+version = "0.1.3"
 
 [[deps.MultivariateMoments]]
 deps = ["LinearAlgebra", "MultivariateBases", "MultivariatePolynomials", "MutableArithmetics", "RowEchelon", "SemialgebraicSets"]
-git-tree-sha1 = "5f691d93c526df5f8d8d434c9b38e196c3dd1d20"
+git-tree-sha1 = "47155905dcfc3abfe2924577785445614c0cdd93"
 uuid = "f4abf1af-0426-5881-a0da-e2f168889b5e"
-version = "0.3.8"
+version = "0.3.6"
 
 [[deps.MultivariatePolynomials]]
 deps = ["DataStructures", "LinearAlgebra", "MutableArithmetics"]
-git-tree-sha1 = "fa6ce8c91445e7cd54de662064090b14b1089a6d"
+git-tree-sha1 = "45c9940cec79dedcdccc73cc6dd09ea8b8ab142c"
 uuid = "102ac46a-7ee4-5c85-9060-abc95bfdeaa3"
-version = "0.4.2"
+version = "0.3.18"
 
 [[deps.MutableArithmetics]]
 deps = ["LinearAlgebra", "SparseArrays", "Test"]
-git-tree-sha1 = "7bb6853d9afec54019c1397c6eb610b9b9a19525"
+git-tree-sha1 = "8d9496b2339095901106961f44718920732616bb"
 uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
-version = "0.3.1"
+version = "0.2.22"
 
 [[deps.NaNMath]]
-git-tree-sha1 = "bfe47e760d60b82b66b61d2d44128b62e3a369fb"
+git-tree-sha1 = "f755f36b19a5116bb580de457cda0c140153f283"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-version = "0.3.5"
+version = "0.3.6"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -316,9 +341,9 @@ version = "1.4.1"
 
 [[deps.Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "ae4bbcadb2906ccc085cf52ac286dc1377dceccc"
+git-tree-sha1 = "d7fa6237da8004be601e19bd6666083056649918"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.1.2"
+version = "2.1.3"
 
 [[deps.PermutationGroups]]
 deps = ["AbstractAlgebra", "GroupsCore", "Markdown", "Random"]
@@ -331,16 +356,16 @@ deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markd
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[deps.PolyJuMP]]
-deps = ["JuMP", "LinearAlgebra", "MathOptInterface", "MultivariateBases", "MultivariateMoments", "MultivariatePolynomials", "MutableArithmetics", "SemialgebraicSets"]
-git-tree-sha1 = "4bb50766222888fffaa3c254e80f1a3da6c0f0db"
+deps = ["JuMP", "LinearAlgebra", "MathOptInterface", "MultivariateBases", "MultivariateMoments", "MultivariatePolynomials", "SemialgebraicSets"]
+git-tree-sha1 = "3437fa736128ccbc8c90f86954e8a467d52dc557"
 uuid = "ddf597a6-d67e-5340-b84c-e37d84115374"
-version = "0.5.1"
+version = "0.4.3"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "00cfd92944ca9c760982747e9a1d0d5d86ab1e5a"
+git-tree-sha1 = "2cf929d64681236a2e074ffafb8d568733d2e6af"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.2.2"
+version = "1.2.3"
 
 [[deps.Primes]]
 git-tree-sha1 = "984a3ee07d47d401e0b823b7d30546792439070a"
@@ -387,10 +412,10 @@ uuid = "af85af4c-bcd5-5d23-b03a-a909639aa875"
 version = "0.2.1"
 
 [[deps.SCS]]
-deps = ["BinaryProvider", "Libdl", "LinearAlgebra", "MathOptInterface", "Requires", "SCS_GPU_jll", "SCS_jll", "SparseArrays"]
-git-tree-sha1 = "c819d023621358f3c08f08d41bd9354cf1357d35"
+deps = ["BinaryProvider", "Libdl", "LinearAlgebra", "MathOptInterface", "MathProgBase", "Requires", "SCS_GPU_jll", "SCS_jll", "SparseArrays"]
+git-tree-sha1 = "efc1cf417dffb455b74a3d48857ae418098fc8a1"
 uuid = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
-version = "0.8.1"
+version = "0.7.1"
 
 [[deps.SCS_GPU_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "OpenBLAS_jll", "Pkg"]
@@ -408,10 +433,10 @@ version = "2.1.2+1"
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [[deps.SemialgebraicSets]]
-deps = ["LinearAlgebra", "MultivariatePolynomials", "MutableArithmetics", "Random"]
-git-tree-sha1 = "883186c2b0cabf0ffcdf7357cbb5732cd6f07f07"
+deps = ["LinearAlgebra", "MultivariatePolynomials", "Random"]
+git-tree-sha1 = "f4499c57d1b6ce5de7b37a1d857505d3e96d1678"
 uuid = "8e049039-38e8-557d-ae3a-bc521ccf6204"
-version = "0.2.4"
+version = "0.2.3"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -435,31 +460,31 @@ version = "1.8.1"
 
 [[deps.StarAlgebras]]
 deps = ["LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "418f6a4a8d8cc75ede23d94134dd6294552cd6c4"
+git-tree-sha1 = "027b0c890edbac7698345a5dce8431fd55b5e9f6"
 uuid = "0c0c59c1-dc5f-42e9-9a8b-b5dc384a6cd1"
-version = "0.1.5"
+version = "0.1.6"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "3c76dde64d03699e074ac02eb2e8ba8254d428da"
+git-tree-sha1 = "de9e88179b584ba9cf3cc5edbb7a41f26ce42cda"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.2.13"
+version = "1.3.0"
 
 [[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[deps.SumOfSquares]]
-deps = ["Combinatorics", "ComplexOptInterface", "DataStructures", "JuMP", "LinearAlgebra", "MathOptInterface", "MultivariateBases", "MultivariateMoments", "MultivariatePolynomials", "MutableArithmetics", "PolyJuMP", "Reexport", "SemialgebraicSets", "SparseArrays", "SymbolicWedderburn"]
-git-tree-sha1 = "a38aed8a62553bbcbd2e436c8574328a7c63232e"
+deps = ["ComplexOptInterface", "DataStructures", "JuMP", "LinearAlgebra", "MathOptInterface", "MultivariateBases", "MultivariateMoments", "MultivariatePolynomials", "MutableArithmetics", "PolyJuMP", "Reexport", "SemialgebraicSets", "SparseArrays"]
+git-tree-sha1 = "d8323f2f157052c226a31ba44d4018c39d92ca25"
 uuid = "4b9e565b-77fc-50a5-a571-1244f986bda1"
-version = "0.5.0"
+version = "0.4.6"
 
 [[deps.SymbolicWedderburn]]
 deps = ["Cyclotomics", "GroupsCore", "LinearAlgebra", "PermutationGroups", "Primes", "SparseArrays", "StarAlgebras"]
-git-tree-sha1 = "290b908ea4f479f0e549d05fd093078a72a232b9"
+path = "/home/kalmar/.julia/dev/SymbolicWedderburn"
 uuid = "858aa9a9-4c7c-4c62-b466-2421203962a2"
-version = "0.2.0"
+version = "0.3.0"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -478,6 +503,11 @@ deps = ["Random", "Test"]
 git-tree-sha1 = "216b95ea110b5972db65aa90f88d8d89dcb8851c"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 version = "0.9.6"
+
+[[deps.URIs]]
+git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.3.0"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -1,513 +1,503 @@
 # This file is machine-generated - editing it directly is not advised
 
-[[AbstractAlgebra]]
-deps = ["InteractiveUtils", "LinearAlgebra", "Markdown", "Random", "RandomExtensions", "SparseArrays", "Test"]
-git-tree-sha1 = "452f5cdc30c10a372d87cf60da4ead7c8cfc4548"
-uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
-version = "0.16.0"
+julia_version = "1.7.0"
+manifest_format = "2.0"
 
-[[ArgTools]]
+[[deps.AbstractAlgebra]]
+deps = ["GroupsCore", "InteractiveUtils", "LinearAlgebra", "Markdown", "Random", "RandomExtensions", "SparseArrays", "Test"]
+git-tree-sha1 = "b5c1a469f9afd3a9d79930d2cead20c562458aae"
+uuid = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"
+version = "0.22.3"
+
+[[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 
-[[Artifacts]]
+[[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
-[[Base64]]
+[[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[BenchmarkTools]]
+[[deps.BenchmarkTools]]
 deps = ["JSON", "Logging", "Printf", "Profile", "Statistics", "UUIDs"]
-git-tree-sha1 = "61adeb0823084487000600ef8b1c00cc2474cd47"
+git-tree-sha1 = "940001114a0147b6e4d10624276d56d531dd9b49"
 uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-version = "1.2.0"
+version = "1.2.2"
 
-[[BinaryProvider]]
+[[deps.BinaryProvider]]
 deps = ["Libdl", "Logging", "SHA"]
 git-tree-sha1 = "ecdec412a9abc8db54c0efc5548c64dfce072058"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 version = "0.5.10"
 
-[[Bzip2_jll]]
+[[deps.Bzip2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "19a35467a82e236ff51bc17a3a44b69ef35185a2"
 uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
 version = "1.0.8+0"
 
-[[Calculus]]
+[[deps.Calculus]]
 deps = ["LinearAlgebra"]
 git-tree-sha1 = "f641eb0a4f00c343bbc32346e1217b86f3ce9dad"
 uuid = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
 version = "0.5.1"
 
-[[ChainRulesCore]]
+[[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "e8a30e8019a512e4b6c56ccebc065026624660e8"
+git-tree-sha1 = "4c26b4e9e91ca528ea212927326ece5918a04b47"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.7.0"
+version = "1.11.2"
 
-[[CodecBzip2]]
+[[deps.ChangesOfVariables]]
+deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
+git-tree-sha1 = "bf98fa45a0a4cee295de98d4c1462be26345b9a1"
+uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+version = "0.1.2"
+
+[[deps.CodecBzip2]]
 deps = ["Bzip2_jll", "Libdl", "TranscodingStreams"]
 git-tree-sha1 = "2e62a725210ce3c3c2e1a3080190e7ca491f18d7"
 uuid = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
 version = "0.7.2"
 
-[[CodecZlib]]
+[[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
 git-tree-sha1 = "ded953804d019afa9a3f98981d99b33e3db7b6da"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
 version = "0.7.0"
 
-[[Combinatorics]]
+[[deps.Combinatorics]]
 git-tree-sha1 = "08c8b6831dc00bfea825826be0bc8336fc369860"
 uuid = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 version = "1.0.2"
 
-[[CommonSubexpressions]]
+[[deps.CommonSubexpressions]]
 deps = ["MacroTools", "Test"]
 git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
 uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
 version = "0.3.0"
 
-[[Compat]]
+[[deps.Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "31d0151f5716b655421d9d75b7fa74cc4e744df2"
+git-tree-sha1 = "44c37b4636bc54afac5c574d2d02b625349d6582"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.39.0"
+version = "3.41.0"
 
-[[CompilerSupportLibraries_jll]]
+[[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 
-[[ComplexOptInterface]]
+[[deps.ComplexOptInterface]]
 deps = ["MathOptInterface", "MutableArithmetics"]
-git-tree-sha1 = "343cdb56037209f6be1f4f967f23c65a279d1a63"
+git-tree-sha1 = "4cd32b867e7d1f8b522461cd9312d380dfec0bb3"
 uuid = "25c3070e-1275-41b5-afef-2f982c87090a"
-version = "0.0.2"
+version = "0.0.3"
 
-[[Cyclotomics]]
+[[deps.Cyclotomics]]
 deps = ["LRUCache", "Memoize", "Primes", "SparseArrays", "Test"]
 git-tree-sha1 = "aff368c5b38052cc10140d6c3cdcd2b5862903f8"
 uuid = "da8f5974-afbb-4dc8-91d8-516d5257c83b"
 version = "0.2.3"
 
-[[DataStructures]]
+[[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "7d9d316f04214f7efdbb6398d545446e246eff02"
+git-tree-sha1 = "3daef5523dd2e769dad2365274f760ff5f282c7d"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.10"
+version = "0.18.11"
 
-[[Dates]]
+[[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
-[[DelimitedFiles]]
+[[deps.DelimitedFiles]]
 deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
-[[DiffResults]]
+[[deps.DiffResults]]
 deps = ["StaticArrays"]
 git-tree-sha1 = "c18e98cba888c6c25d1c3b048e4b3380ca956805"
 uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
 version = "1.0.3"
 
-[[DiffRules]]
-deps = ["NaNMath", "Random", "SpecialFunctions"]
-git-tree-sha1 = "7220bc21c33e990c14f4a9a319b1d242ebc5b269"
+[[deps.DiffRules]]
+deps = ["LogExpFunctions", "NaNMath", "Random", "SpecialFunctions"]
+git-tree-sha1 = "9bc5dac3c8b6706b58ad5ce24cffd9861f07c94f"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.3.1"
+version = "1.9.0"
 
-[[Distributed]]
+[[deps.Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
-[[DocStringExtensions]]
+[[deps.DocStringExtensions]]
 deps = ["LibGit2"]
-git-tree-sha1 = "a32185f5428d3986f47c2ab78b1f216d5e6cc96f"
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.5"
+version = "0.8.6"
 
-[[Downloads]]
+[[deps.Downloads]]
 deps = ["ArgTools", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
-[[DynamicPolynomials]]
+[[deps.DynamicPolynomials]]
 deps = ["DataStructures", "Future", "LinearAlgebra", "MultivariatePolynomials", "MutableArithmetics", "Pkg", "Reexport", "Test"]
-git-tree-sha1 = "05b68e727a192783be0b34bd8fee8f678505c0bf"
+git-tree-sha1 = "585de0d658506cf0fe5808026edff662bef5bf03"
 uuid = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
-version = "0.3.20"
+version = "0.4.1"
 
-[[ForwardDiff]]
-deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "NaNMath", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
-git-tree-sha1 = "b5e930ac60b613ef3406da6d4f42c35d8dc51419"
+[[deps.ForwardDiff]]
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
+git-tree-sha1 = "2b72a5624e289ee18256111657663721d59c143e"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.19"
+version = "0.10.24"
 
-[[Future]]
+[[deps.Future]]
 deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
-[[GroupsCore]]
-deps = ["AbstractAlgebra", "Markdown", "Random"]
-git-tree-sha1 = "2c5be56967dd05928c6029dd3782db207e7f683c"
+[[deps.GroupsCore]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "9e1a5e9f3b81ad6a5c613d181664a0efc6fe6dd7"
 uuid = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"
-version = "0.3.2"
+version = "0.4.0"
 
-[[HTTP]]
-deps = ["Base64", "Dates", "IniFile", "Logging", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
-git-tree-sha1 = "24675428ca27678f003414a98c9e473e45fe6a21"
-uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.9.15"
-
-[[IniFile]]
-deps = ["Test"]
-git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
-uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
-version = "0.5.0"
-
-[[InteractiveUtils]]
+[[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
-[[IrrationalConstants]]
-git-tree-sha1 = "f76424439413893a832026ca355fe273e93bce94"
-uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
-version = "0.1.0"
+[[deps.InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "a7254c0acd8e62f1ac75ad24d5db43f5f19f3c65"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.2"
 
-[[JLLWrappers]]
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.1.1"
+
+[[deps.JLLWrappers]]
 deps = ["Preferences"]
 git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.3.0"
 
-[[JSON]]
+[[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
 git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.2"
 
-[[JSONSchema]]
-deps = ["HTTP", "JSON", "URIs"]
-git-tree-sha1 = "2f49f7f86762a0fbbeef84912265a1ae61c4ef80"
-uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
-version = "0.3.4"
-
-[[JuMP]]
+[[deps.JuMP]]
 deps = ["Calculus", "DataStructures", "ForwardDiff", "JSON", "LinearAlgebra", "MathOptInterface", "MutableArithmetics", "NaNMath", "Printf", "Random", "SparseArrays", "SpecialFunctions", "Statistics"]
-git-tree-sha1 = "4358b7cbf2db36596bdbbe3becc6b9d87e4eb8f5"
+git-tree-sha1 = "de9c69c0862be0e11afe5d4aa3426af1d7ecac2c"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
-version = "0.21.10"
+version = "0.22.1"
 
-[[LRUCache]]
+[[deps.LRUCache]]
 git-tree-sha1 = "d64a0aff6691612ab9fb0117b0995270871c5dfc"
 uuid = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 version = "1.3.0"
 
-[[LibCURL]]
+[[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 
-[[LibCURL_jll]]
+[[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
 
-[[LibGit2]]
+[[deps.LibGit2]]
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
-[[LibSSH2_jll]]
+[[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 
-[[Libdl]]
+[[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
-[[LinearAlgebra]]
-deps = ["Libdl"]
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
-[[LogExpFunctions]]
-deps = ["ChainRulesCore", "DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "34dc30f868e368f8a17b728a1238f3fcda43931a"
+[[deps.LogExpFunctions]]
+deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "be9eef9f9d78cecb6f262f3c10da151a6c5ab827"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.3"
+version = "0.3.5"
 
-[[Logging]]
+[[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
-[[MacroTools]]
+[[deps.MacroTools]]
 deps = ["Markdown", "Random"]
-git-tree-sha1 = "5a5bc6bf062f0f95e62d0fe0a2d99699fed82dd9"
+git-tree-sha1 = "3d3e902b31198a27340d0bf00d6ac452866021cf"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.8"
+version = "0.5.9"
 
-[[Markdown]]
+[[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
-[[MathOptInterface]]
-deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "JSON", "JSONSchema", "LinearAlgebra", "MutableArithmetics", "OrderedCollections", "SparseArrays", "Test", "Unicode"]
-git-tree-sha1 = "575644e3c05b258250bb599e57cf73bbf1062901"
+[[deps.MathOptInterface]]
+deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "JSON", "LinearAlgebra", "MutableArithmetics", "OrderedCollections", "Printf", "SparseArrays", "Test", "Unicode"]
+git-tree-sha1 = "92b7de61ecb616562fd2501334f729cc9db2a9a6"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "0.9.22"
+version = "0.10.6"
 
-[[MathProgBase]]
-deps = ["LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "9abbe463a1e9fc507f12a69e7f29346c2cdc472c"
-uuid = "fdba3010-5040-5b88-9595-932c9decdf73"
-version = "0.7.8"
-
-[[MbedTLS]]
-deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
-git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
-uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "1.0.3"
-
-[[MbedTLS_jll]]
+[[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 
-[[Memoize]]
+[[deps.Memoize]]
 deps = ["MacroTools"]
 git-tree-sha1 = "2b1dfcba103de714d31c033b5dacc2e4a12c7caa"
 uuid = "c03570c3-d221-55d1-a50c-7939bbd78826"
 version = "0.4.4"
 
-[[Mmap]]
+[[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
-[[MozillaCACerts_jll]]
+[[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 
-[[MultivariateBases]]
+[[deps.MultivariateBases]]
 deps = ["MultivariatePolynomials", "MutableArithmetics"]
-git-tree-sha1 = "7537fef91585f2ff805bbdb1f903ad982f104149"
+git-tree-sha1 = "7759e4f8151b41b08be48ba6b7941c028d0cdc4c"
 uuid = "be282fd4-ad43-11e9-1d11-8bd9d7e43378"
-version = "0.1.3"
+version = "0.1.4"
 
-[[MultivariateMoments]]
+[[deps.MultivariateMoments]]
 deps = ["LinearAlgebra", "MultivariateBases", "MultivariatePolynomials", "MutableArithmetics", "RowEchelon", "SemialgebraicSets"]
-git-tree-sha1 = "47155905dcfc3abfe2924577785445614c0cdd93"
+git-tree-sha1 = "5f691d93c526df5f8d8d434c9b38e196c3dd1d20"
 uuid = "f4abf1af-0426-5881-a0da-e2f168889b5e"
-version = "0.3.6"
+version = "0.3.8"
 
-[[MultivariatePolynomials]]
+[[deps.MultivariatePolynomials]]
 deps = ["DataStructures", "LinearAlgebra", "MutableArithmetics"]
-git-tree-sha1 = "45c9940cec79dedcdccc73cc6dd09ea8b8ab142c"
+git-tree-sha1 = "fa6ce8c91445e7cd54de662064090b14b1089a6d"
 uuid = "102ac46a-7ee4-5c85-9060-abc95bfdeaa3"
-version = "0.3.18"
+version = "0.4.2"
 
-[[MutableArithmetics]]
+[[deps.MutableArithmetics]]
 deps = ["LinearAlgebra", "SparseArrays", "Test"]
-git-tree-sha1 = "3927848ccebcc165952dc0d9ac9aa274a87bfe01"
+git-tree-sha1 = "7bb6853d9afec54019c1397c6eb610b9b9a19525"
 uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
-version = "0.2.20"
+version = "0.3.1"
 
-[[NaNMath]]
+[[deps.NaNMath]]
 git-tree-sha1 = "bfe47e760d60b82b66b61d2d44128b62e3a369fb"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 version = "0.3.5"
 
-[[NetworkOptions]]
+[[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
-[[OpenBLAS_jll]]
+[[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
 
-[[OpenLibm_jll]]
+[[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
 
-[[OpenSpecFun_jll]]
+[[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "13652491f6856acfd2db29360e1bbcd4565d04f1"
 uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 version = "0.5.5+0"
 
-[[OrderedCollections]]
+[[deps.OrderedCollections]]
 git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.4.1"
 
-[[Parsers]]
+[[deps.Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "9d8c00ef7a8d110787ff6f170579846f776133a9"
+git-tree-sha1 = "ae4bbcadb2906ccc085cf52ac286dc1377dceccc"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.0.4"
+version = "2.1.2"
 
-[[PermutationGroups]]
+[[deps.PermutationGroups]]
 deps = ["AbstractAlgebra", "GroupsCore", "Markdown", "Random"]
-git-tree-sha1 = "2834ae296e09521325a431925eba590cd6a01187"
+git-tree-sha1 = "a06095cec7128a532c2b0bf924d2d982b4e2a595"
 uuid = "8bc5a954-2dfc-11e9-10e6-cd969bffa420"
-version = "0.3.0"
+version = "0.3.2"
 
-[[Pkg]]
+[[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
-[[PolyJuMP]]
-deps = ["JuMP", "LinearAlgebra", "MathOptInterface", "MultivariateBases", "MultivariateMoments", "MultivariatePolynomials", "SemialgebraicSets"]
-git-tree-sha1 = "3437fa736128ccbc8c90f86954e8a467d52dc557"
+[[deps.PolyJuMP]]
+deps = ["JuMP", "LinearAlgebra", "MathOptInterface", "MultivariateBases", "MultivariateMoments", "MultivariatePolynomials", "MutableArithmetics", "SemialgebraicSets"]
+git-tree-sha1 = "4bb50766222888fffaa3c254e80f1a3da6c0f0db"
 uuid = "ddf597a6-d67e-5340-b84c-e37d84115374"
-version = "0.4.3"
+version = "0.5.1"
 
-[[Preferences]]
+[[deps.Preferences]]
 deps = ["TOML"]
 git-tree-sha1 = "00cfd92944ca9c760982747e9a1d0d5d86ab1e5a"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
 version = "1.2.2"
 
-[[Primes]]
-git-tree-sha1 = "afccf037da52fa596223e5a0e331ff752e0e845c"
+[[deps.Primes]]
+git-tree-sha1 = "984a3ee07d47d401e0b823b7d30546792439070a"
 uuid = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
-version = "0.5.0"
+version = "0.5.1"
 
-[[Printf]]
+[[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
-[[Profile]]
+[[deps.Profile]]
 deps = ["Printf"]
 uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 
-[[REPL]]
+[[deps.REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
-[[Random]]
-deps = ["Serialization"]
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
-[[RandomExtensions]]
+[[deps.RandomExtensions]]
 deps = ["Random", "SparseArrays"]
 git-tree-sha1 = "062986376ce6d394b23d5d90f01d81426113a3c9"
 uuid = "fb686558-2515-59ef-acaa-46db3789a887"
 version = "0.4.3"
 
-[[Reexport]]
+[[deps.Reexport]]
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "1.2.2"
 
-[[Requires]]
+[[deps.Requires]]
 deps = ["UUIDs"]
-git-tree-sha1 = "4036a3bd08ac7e968e27c203d45f5fff15020621"
+git-tree-sha1 = "8f82019e525f4d5c669692772a6f4b0a58b06a6a"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
-version = "1.1.3"
+version = "1.2.0"
 
-[[RowEchelon]]
+[[deps.RowEchelon]]
 deps = ["LinearAlgebra"]
 git-tree-sha1 = "f479526c4f6efcbf01e7a8f4223d62cfe801c974"
 uuid = "af85af4c-bcd5-5d23-b03a-a909639aa875"
 version = "0.2.1"
 
-[[SCS]]
-deps = ["BinaryProvider", "Libdl", "LinearAlgebra", "MathOptInterface", "MathProgBase", "Requires", "SCS_GPU_jll", "SCS_jll", "SparseArrays"]
-git-tree-sha1 = "efc1cf417dffb455b74a3d48857ae418098fc8a1"
+[[deps.SCS]]
+deps = ["BinaryProvider", "Libdl", "LinearAlgebra", "MathOptInterface", "Requires", "SCS_GPU_jll", "SCS_jll", "SparseArrays"]
+git-tree-sha1 = "c819d023621358f3c08f08d41bd9354cf1357d35"
 uuid = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
-version = "0.7.1"
+version = "0.8.1"
 
-[[SCS_GPU_jll]]
+[[deps.SCS_GPU_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "OpenBLAS_jll", "Pkg"]
 git-tree-sha1 = "a96402e3b494a8bbec61b1adb86d4be04112c646"
 uuid = "af6e375f-46ec-5fa0-b791-491b0dfa44a4"
 version = "2.1.4+0"
 
-[[SCS_jll]]
+[[deps.SCS_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "OpenBLAS_jll", "Pkg"]
-git-tree-sha1 = "66c07568ecec96260aaac194ee1e5ee8df62f386"
+git-tree-sha1 = "6cdaccb5e6a69455f960de1ae445ba1de5db9d0d"
 uuid = "f4f2fc5b-1d94-523c-97ea-2ab488bedf4b"
-version = "2.1.4+0"
+version = "2.1.2+1"
 
-[[SHA]]
+[[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
-[[SemialgebraicSets]]
-deps = ["LinearAlgebra", "MultivariatePolynomials", "Random"]
-git-tree-sha1 = "f4499c57d1b6ce5de7b37a1d857505d3e96d1678"
+[[deps.SemialgebraicSets]]
+deps = ["LinearAlgebra", "MultivariatePolynomials", "MutableArithmetics", "Random"]
+git-tree-sha1 = "883186c2b0cabf0ffcdf7357cbb5732cd6f07f07"
 uuid = "8e049039-38e8-557d-ae3a-bc521ccf6204"
-version = "0.2.3"
+version = "0.2.4"
 
-[[Serialization]]
+[[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
-[[SharedArrays]]
+[[deps.SharedArrays]]
 deps = ["Distributed", "Mmap", "Random", "Serialization"]
 uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 
-[[Sockets]]
+[[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
-[[SparseArrays]]
+[[deps.SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
-[[SpecialFunctions]]
+[[deps.SpecialFunctions]]
 deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "793793f1df98e3d7d554b65a107e9c9a6399a6ed"
+git-tree-sha1 = "f0bccf98e16759818ffc5d97ac3ebf87eb950150"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.7.0"
+version = "1.8.1"
 
-[[StaticArrays]]
+[[deps.StarAlgebras]]
+deps = ["LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "418f6a4a8d8cc75ede23d94134dd6294552cd6c4"
+uuid = "0c0c59c1-dc5f-42e9-9a8b-b5dc384a6cd1"
+version = "0.1.5"
+
+[[deps.StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "3240808c6d463ac46f1c1cd7638375cd22abbccb"
+git-tree-sha1 = "3c76dde64d03699e074ac02eb2e8ba8254d428da"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.2.12"
+version = "1.2.13"
 
-[[Statistics]]
+[[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
-[[SumOfSquares]]
+[[deps.SumOfSquares]]
 deps = ["Combinatorics", "ComplexOptInterface", "DataStructures", "JuMP", "LinearAlgebra", "MathOptInterface", "MultivariateBases", "MultivariateMoments", "MultivariatePolynomials", "MutableArithmetics", "PolyJuMP", "Reexport", "SemialgebraicSets", "SparseArrays", "SymbolicWedderburn"]
-git-tree-sha1 = "514777215559fbf8dd3d9489187d119ace65c7d1"
+git-tree-sha1 = "a38aed8a62553bbcbd2e436c8574328a7c63232e"
 uuid = "4b9e565b-77fc-50a5-a571-1244f986bda1"
-version = "0.4.7"
+version = "0.5.0"
 
-[[SymbolicWedderburn]]
-deps = ["Cyclotomics", "GroupsCore", "LinearAlgebra", "PermutationGroups", "Primes", "SparseArrays"]
-git-tree-sha1 = "efcea932bd5ab852729e1ee727eb867f1f9002c9"
+[[deps.SymbolicWedderburn]]
+deps = ["Cyclotomics", "GroupsCore", "LinearAlgebra", "PermutationGroups", "Primes", "SparseArrays", "StarAlgebras"]
+git-tree-sha1 = "290b908ea4f479f0e549d05fd093078a72a232b9"
 uuid = "858aa9a9-4c7c-4c62-b466-2421203962a2"
-version = "0.1.0"
+version = "0.2.0"
 
-[[TOML]]
+[[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
-[[Tar]]
+[[deps.Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 
-[[Test]]
+[[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[[TranscodingStreams]]
+[[deps.TranscodingStreams]]
 deps = ["Random", "Test"]
 git-tree-sha1 = "216b95ea110b5972db65aa90f88d8d89dcb8851c"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 version = "0.9.6"
 
-[[URIs]]
-git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
-uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.3.0"
-
-[[UUIDs]]
+[[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
-[[Unicode]]
+[[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
-[[Zlib_jll]]
+[[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 
-[[nghttp2_jll]]
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+
+[[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
 
-[[p7zip_jll]]
+[[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/examples/action_polynomials.jl
+++ b/examples/action_polynomials.jl
@@ -1,5 +1,5 @@
 using DynamicPolynomials
-MP = DynamicPolynomials.MultivariatePolynomials
+const  MPoly = DynamicPolynomials.MultivariatePolynomials
 using GroupsCore
 using PermutationGroups
 
@@ -19,26 +19,26 @@ abstract type OnMonomials <: SymbolicWedderburn.ByLinearTransformation end
 function SymbolicWedderburn.action(
     a::Union{VariablePermutation,OnMonomials},
     el::GroupElement,
-    term::MP.AbstractTerm,
+    term::MPoly.AbstractTerm,
 )
-    return MP.coefficient(term) * SymbolicWedderburn.action(a, el, MP.monomial(term))
+    return MPoly.coefficient(term) * SymbolicWedderburn.action(a, el, MPoly.monomial(term))
 end
 function SymbolicWedderburn.action(
     a::Union{VariablePermutation,OnMonomials},
     el::GroupElement,
-    poly::MP.AbstractPolynomial,
+    poly::MPoly.AbstractPolynomial,
 )
-    return sum([SymbolicWedderburn.action(a, el, term) for term in MP.terms(poly)])
+    return sum([SymbolicWedderburn.action(a, el, term) for term in MPoly.terms(poly)])
 end
 
 function SymbolicWedderburn.decompose(
-    k::MP.AbstractPolynomialLike,
+    k::MPoly.AbstractPolynomialLike,
     hom::SymbolicWedderburn.InducedActionHomomorphism,
 )
     # correct only if basis(hom) == monomials
-
-    indcs = [hom[mono] for mono in MP.monomials(k)]
-    coeffs = MP.coefficients(k)
+    I = SymbolicWedderburn._int_type(hom)
+    indcs = I[hom[mono] for mono in MPoly.monomials(k)]
+    coeffs = MPoly.coefficients(k)
 
     return indcs, coeffs
 end

--- a/examples/action_polynomials.jl
+++ b/examples/action_polynomials.jl
@@ -35,7 +35,7 @@ function SymbolicWedderburn.decompose(
     k::MP.AbstractPolynomialLike,
     hom::SymbolicWedderburn.InducedActionHomomorphism,
 )
-    # correct only if features(hom) == monomials
+    # correct only if basis(hom) == monomials
 
     indcs = [hom[mono] for mono in MP.monomials(k)]
     coeffs = MP.coefficients(k)

--- a/examples/ex_C2_linear.jl
+++ b/examples/ex_C2_linear.jl
@@ -20,7 +20,7 @@ function SymbolicWedderburn.action(::By90Rotation, g::CyclicGroupElement, m::Mon
 end
 
 function SymbolicWedderburn.decompose(k::AbstractPolynomial, hom::SymbolicWedderburn.InducedActionHomomorphism)
-    # correct only if features(hom) == monomials
+    # correct only if basis(hom) == monomials
 
     indcs = [hom[m] for m in monomials(k)]
     coeffs = coefficients(k)

--- a/examples/ex_S4.jl
+++ b/examples/ex_S4.jl
@@ -3,12 +3,13 @@ using PermutationGroups
 using Cyclotomics
 
 using SparseArrays
+using LinearAlgebra
 
 using DynamicPolynomials
 using SumOfSquares
 using SCS
 
-const OPTIMIZER = optimizer_with_attributes(
+OPTIMIZER = optimizer_with_attributes(
     SCS.Optimizer,
     "acceleration_lookback" => 10,
     "max_iters" => 10_000,

--- a/examples/ex_motzkin.jl
+++ b/examples/ex_motzkin.jl
@@ -12,7 +12,7 @@ include(joinpath(@__DIR__, "action_polynomials.jl"))
 OPTIMIZER = optimizer_with_attributes(
     SCS.Optimizer,
     "acceleration_lookback" => 0,
-    "max_iters" => 10_000,
+    "max_iters" => 20_000,
     "eps" => 2e-6,
     "linear_solver" => SCS.DirectSolver,
 )

--- a/examples/ex_robinson_form.jl
+++ b/examples/ex_robinson_form.jl
@@ -142,7 +142,11 @@ orbit_dec = let f = robinson_form, G = DihedralGroup(4), T = Float64
 
     invariant_vs, symmetry_adaptation_time, = @timed let G = G
         tblG = SymbolicWedderburn.Characters.CharacterTable(Rational{Int}, G)
-        invariant_vectors(tblG, DihedralAction(), basis_monoms)
+        invariant_vectors(
+            tblG,
+            DihedralAction(),
+            StarAlgebras.Basis{UInt32}(basis_monoms),
+        )
     end
 
     M = let basis_full = StarAlgebras.Basis{UInt32}(basis_monoms), basis_half = monomials([x,y], 0:(DynamicPolynomials.maxdegree(f) ÷ 2))

--- a/examples/ex_robinson_form.jl
+++ b/examples/ex_robinson_form.jl
@@ -16,11 +16,11 @@ using DynamicPolynomials
 using SumOfSquares
 using SCS
 
-const OPTIMIZER = optimizer_with_attributes(
+OPTIMIZER = optimizer_with_attributes(
     SCS.Optimizer,
     "acceleration_lookback" => 10,
     "max_iters" => 3_000,
-    "alpha" => 1.95,
+    "alpha" => 1.2,
     "eps" => 1e-6,
     "linear_solver" => SCS.DirectSolver,
 )
@@ -140,7 +140,10 @@ include(joinpath(@__DIR__, "util.jl"))
 orbit_dec = let f = robinson_form, G = DihedralGroup(4), T = Float64
     basis_monoms = monomials([x,y], 0:DynamicPolynomials.maxdegree(f))
 
-    invariant_vs, symmetry_adaptation_time, = @timed invariant_vectors(G, DihedralAction(), basis_monoms)
+    invariant_vs, symmetry_adaptation_time, = @timed let G = G
+        tblG = SymbolicWedderburn.Characters.CharacterTable(Rational{Int}, G)
+        invariant_vectors(tblG, DihedralAction(), basis_monoms)
+    end
 
     M = let basis_full = StarAlgebras.Basis{UInt32}(basis_monoms), basis_half = monomials([x,y], 0:(DynamicPolynomials.maxdegree(f) ÷ 2))
         [basis_full[x * y] for x in basis_half, y in basis_half]

--- a/examples/ex_robinson_form.jl
+++ b/examples/ex_robinson_form.jl
@@ -52,6 +52,7 @@ function SymbolicWedderburn.action(
     el::DihedralElement,
     mono::AbstractMonomial,
 )
+    x, y = variables(mono)
     if iseven(el.reflection + el.id)
         var_x, var_y = x, y
     else

--- a/examples/run_examples.jl
+++ b/examples/run_examples.jl
@@ -1,0 +1,7 @@
+using Pkg
+Pkg.activate(@__DIR__)
+Pkg.instantiate()
+include(joinpath(@__DIR__, "ex_C2_linear.jl"))
+include(joinpath(@__DIR__, "ex_S4.jl"))
+include(joinpath(@__DIR__, "ex_motzkin.jl"))
+include(joinpath(@__DIR__, "ex_robinson_form.jl"))

--- a/src/Characters/character_tables.jl
+++ b/src/Characters/character_tables.jl
@@ -36,6 +36,10 @@ function irreducible_characters(
     return irreducible_characters(CharacterTable(R, G, cclasses))
 end
 
+@static if VERSION < v"1.1"
+	eachrow(A::AbstractMatrix) = [A[i, :] for i in 1:size(A,1)]
+end
+
 trivial_character(chtbl::CharacterTable) =
 	   Character(chtbl, findfirst(r->all(isone, r), eachrow(chtbl)))
 

--- a/src/Characters/character_tables.jl
+++ b/src/Characters/character_tables.jl
@@ -24,7 +24,7 @@ nirreps(chtbl::CharacterTable) = size(chtbl.values, 1)
 irreducible_characters(chtbl::CharacterTable) =
     [Character(chtbl, i) for i in 1:size(chtbl, 1)]
 irreducible_characters(T::Type, chtbl::CharacterTable) =
-    [Character{T}(chtbl, i) for i in 1:size(chtbl, 1)]
+    Character{T}[Character{T}(chtbl, i) for i in 1:size(chtbl, 1)]
 irreducible_characters(G::Group, cclasses = conjugacy_classes(G)) =
     irreducible_characters(Rational{Int}, G, cclasses)
 

--- a/src/Characters/character_tables.jl
+++ b/src/Characters/character_tables.jl
@@ -36,12 +36,16 @@ function irreducible_characters(
     return irreducible_characters(CharacterTable(R, G, cclasses))
 end
 
-@static if VERSION < v"1.1"
-	eachrow(A::AbstractMatrix) = [A[i, :] for i in 1:size(A,1)]
+function trivial_character(chtbl::CharacterTable)
+	# return Character(chtbl, findfirst(r->all(isone, r), eachrow(chtbl)))
+	# can't use findfirst(f, eachrow(...)) on julia-1.6
+	for i in 1:size(chtbl, 1)
+		all(isone, @view(chtbl[i, :])) && return Character(chtbl, i)
+	end
+	# never hit, to keep compiler happy
+	return Character(chtbl, 0)
 end
 
-trivial_character(chtbl::CharacterTable) =
-	   Character(chtbl, findfirst(r->all(isone, r), eachrow(chtbl)))
 
 ## construcing tables
 

--- a/src/Characters/character_tables.jl
+++ b/src/Characters/character_tables.jl
@@ -36,6 +36,9 @@ function irreducible_characters(
     return irreducible_characters(CharacterTable(R, G, cclasses))
 end
 
+trivial_character(chtbl::CharacterTable) =
+	   Character(chtbl, findfirst(r->all(isone, r), eachrow(chtbl)))
+
 ## construcing tables
 
 function CharacterTable(

--- a/src/Characters/class_functions.jl
+++ b/src/Characters/class_functions.jl
@@ -121,7 +121,7 @@ constituents(χ::Character) = χ.constituents
 ## AbstractClassFunction api
 Base.parent(χ::Character) = parent(table(χ))
 conjugacy_classes(χ::Character) = conjugacy_classes(table(χ))
-Base.values(χ::Character) = (χ[i] for i in 1:nconjugacy_classes(table(χ)))
+Base.values(χ::Character{T}) where T = T[χ[i] for i in 1:nconjugacy_classes(table(χ))]
 
 Base.@propagate_inbounds function Base.getindex(
     χ::Character{T},

--- a/src/Characters/class_functions.jl
+++ b/src/Characters/class_functions.jl
@@ -92,12 +92,17 @@ struct Character{T, S, ChT<:CharacterTable} <: AbstractClassFunction{T}
     constituents::Vector{S}
 end
 
-function Character(
+function Character{R}(
     chtbl::CharacterTable{Gr, T},
     constituents::AbstractVector{S}
-) where {Gr, T, S}
-    R = Base._return_type(*, Tuple{S,T})
+) where {R, Gr, T, S}
     return Character{R, S, typeof(chtbl)}(chtbl, constituents)
+end
+
+function Character(chtbl::CharacterTable, constituents::AbstractVector)
+    R = Base._return_type(*, Tuple{eltype(chtbl), eltype(constituents)})
+    @assert R ≠ Any
+    return Character{R}(chtbl, constituents)
 end
 
 Character(chtbl::CharacterTable, i::Integer) = Character{eltype(chtbl)}(chtbl, i)

--- a/src/Characters/echelon_form.jl
+++ b/src/Characters/echelon_form.jl
@@ -36,7 +36,7 @@ Base.@propagate_inbounds function _reduce_column_by_pivot!(
     @boundscheck checkbounds(A, row_idx, col_idx)
     @boundscheck 1 ≤ starting_at ≤ size(A, 2)
 
-    Threads.@threads for ridx in 1:size(A, 1)
+    for ridx in 1:size(A, 1)
         ridx == row_idx && continue
         v = A[ridx, col_idx]
         iszero(v) && continue
@@ -91,7 +91,7 @@ Base.@propagate_inbounds function _reduce_column_by_pivot!(
     @boundscheck checkbounds(A, row_idx, col_idx)
     @boundscheck 1 ≤ starting_at ≤ size(A, 2)
 
-    Threads.@threads for ridx in 1:size(A, 1)
+    for ridx in 1:size(A, 1)
         ridx == row_idx && continue
         @inbounds v = A[ridx, col_idx]
         if abs(v) < eps(T)

--- a/src/SymbolicWedderburn.jl
+++ b/src/SymbolicWedderburn.jl
@@ -17,13 +17,6 @@ export basis,
     issimple,
     multiplicity
 
-macro spawn_compat(expr)
-    @static if VERSION < v"1.3.0"
-        return :(@async $(esc(expr)))
-    else
-        return :(Threads.@spawn $(esc(expr)))
-    end
-end
 
 include("Characters/Characters.jl")
 using .Characters

--- a/src/actions.jl
+++ b/src/actions.jl
@@ -136,20 +136,18 @@ end
 CachedExtensionHomomorphism{G,H}(hom::InducedActionHomomorphism) where {G,H} =
     CachedExtensionHomomorphism(hom, Dict{G,H}())
 
-function induce(ac::Action, hom::CachedExtensionHomomorphism, g::GroupElement)
+function _induce(ac::Action, hom::CachedExtensionHomomorphism, g::GroupElement)
     if !haskey(hom.cache, g)
         hom.cache[g] = induce(ac, hom.ehom, g)
     end
     return hom.cache[g]
 end
-#disambiguation:
-function induce(
+
+induce(ac::Action, hom::CachedExtensionHomomorphism, g::GroupElement) =
+    _induce(ac, hom, g)
+# disabmiguation:
+induce(
     ac::ByLinearTransformation,
     hom::CachedExtensionHomomorphism,
     g::GroupElement,
-)
-    if !haskey(hom.cache, g)
-        hom.cache[g] = induce(ac, hom.ehom, g)
-    end
-    return hom.cache[g]
-end
+) = _induce(ac, hom, g)

--- a/src/actions.jl
+++ b/src/actions.jl
@@ -41,6 +41,8 @@ decompose(x::Any, hom::InducedActionHomomorphism) = throw(
 coeff_type(ac::ByLinearTransformation) = throw(
     "No fallback is provided for $(typeof(ac)). You need to implement `_coeff_type(::$(typeof(ac)))`.",
 )
+coeff_type(hom::InducedActionHomomorphism) = coeff_type(action(hom))
+coeff_type(::ByPermutations) = Int
 
 # Exceeding typemax(UInt16) here would mean e.g. that you're trying to block-diagonalize
 # an SDP constraint of size 65535×65535, which is highly unlikely ;)

--- a/src/matrix_projections.jl
+++ b/src/matrix_projections.jl
@@ -390,10 +390,3 @@ function image_basis!(A::AbstractMatrix{T}) where {T<:Union{AbstractFloat,Comple
     return fact.Vt, 1:length(p)
 end
 
-import Arpack
-
-function image_basis!(A::SparseMatrixCSC{T}) where {T<:AbstractFloat}
-    A, p = row_echelon_form!(A)
-    fact, _ = Arpack.svds(A, nsv = length(p))
-    return fact.Vt, 1:length(p)
-end

--- a/src/matrix_projections.jl
+++ b/src/matrix_projections.jl
@@ -388,10 +388,11 @@ function image_basis!(A::AbstractSparseMatrix)
     return A, p
 end
 
-function image_basis!(A::AbstractMatrix{T}) where {T<:AbstractFloat}
+function image_basis!(A::AbstractMatrix{T}) where {T<:Union{AbstractFloat,Complex}}
     A, p = row_echelon_form!(A)
     fact = svd!(convert(Matrix{T}, @view(A[1:length(p), :])))
-    A_rank = sum(fact.S .> maximum(size(A)) * eps(T))
+    m = T <: Complex ? 2eps(real(T)) : eps(T)
+    A_rank = sum(fact.S .> maximum(size(A)) * m)
     @assert A_rank == length(p)
     return fact.Vt, 1:length(p)
 end
@@ -402,10 +403,4 @@ function image_basis!(A::SparseMatrixCSC{T}) where {T<:AbstractFloat}
     A, p = row_echelon_form!(A)
     fact, _ = Arpack.svds(A, nsv = length(p))
     return fact.Vt, 1:length(p)
-end
-
-function image_basis!(A::AbstractMatrix{T}) where {T<:Complex}
-    fact = svd!(A)
-    A_rank = sum(fact.S .> maximum(size(A)) * 2eps(real(T)))
-    return fact.Vt, 1:A_rank
 end

--- a/src/matrix_projections.jl
+++ b/src/matrix_projections.jl
@@ -1,8 +1,11 @@
 ## preallocation
 
-function _preallocate_spmatrix(::Type{T}, sizes, sizehint) where {T}
-    res = spzeros(T, sizes)
-    sizehint!(res, first(sizes) * sizehint)
+function _preallocate_spmatrix(::Type{T}, sizes::Tuple, sizehint) where {T}
+    res = spzeros(T, sizes...)
+    @static if VERSION >= v"1.7"
+        sizehint!(res, first(sizes) * sizehint)
+    end
+
     return res
 end
 

--- a/src/matrix_projections.jl
+++ b/src/matrix_projections.jl
@@ -335,12 +335,25 @@ function image_basis(hom::InducedActionHomomorphism, α::AlgebraElement)
 end
 
 image_basis!(A::AbstractMatrix) = row_echelon_form!(A)
+function image_basis!(A::AbstractSparseMatrix)
+    A, p = row_echelon_form!(A)
+    dropzeros!(A)
+    return A, p
+end
 
 function image_basis!(A::AbstractMatrix{T}) where {T<:AbstractFloat}
     A, p = row_echelon_form!(A)
     fact = svd!(convert(Matrix{T}, @view(A[1:length(p), :])))
     A_rank = sum(fact.S .> maximum(size(A)) * eps(T))
     @assert A_rank == length(p)
+    return fact.Vt, 1:length(p)
+end
+
+import Arpack
+
+function image_basis!(A::SparseMatrixCSC{T}) where {T<:AbstractFloat}
+    A, p = row_echelon_form!(A)
+    fact, _ = Arpack.svds(A, nsv = length(p))
     return fact.Vt, 1:length(p)
 end
 

--- a/src/matrix_projections.jl
+++ b/src/matrix_projections.jl
@@ -1,32 +1,129 @@
+## preallocation
+
+function _preallocate_spmatrix(::Type{T}, sizes, sizehint) where {T}
+    res = spzeros(T, sizes)
+    sizehint!(res, first(sizes) * sizehint)
+    return res
+end
+
+__an_elt(χ::Character) = first(first(conjugacy_classes(χ)))
+__an_elt(α::AlgebraElement) = first(basis(parent(α)))
+
+_projection_size(p::PermutationGroups.AbstractPerm) = (d = degree(p); (d, d))
+_projection_size(m::AbstractMatrix) = size(m)
+
+_projection_size(χ::Character) = _projection_size(__an_elt(χ))
+_projection_size(hom::InducedActionHomomorphism, χ::Character) =
+    _projection_size(induce(hom, __an_elt(χ)))
+_projection_size(α::AlgebraElement) = _projection_size(__an_elt(α))
+_projection_size(hom::InducedActionHomomorphism, α::AlgebraElement) =
+    _projection_size(induce(hom, __an_elt(χ)))
+
+_hint(χ::Character) = length(conjugacy_classes(χ))
+_hint(α::AlgebraElement) = count(!iszero, StarAlgebras.coeffs(α))
+
+function preallocate(::Type{T}, χ::Union{Character, AlgebraElement}) where {T}
+    sizes = _projection_size(χ)
+    return _preallocate_spmatrix(T, sizes, _hint(χ))
+end
+
+function preallocate(
+    ::Type{T},
+    hom::InducedActionHomomorphism,
+    χ::Union{Character, AlgebraElement},
+) where {T}
+    sizes = _projection_size(hom, χ)
+    return _preallocate_spmatrix(T, sizes, _hint(χ))
+end
+
+## matrix projection [irreducible]
 """
-    matrix_projection_irr([hom::InducedActionHomomorphism, ]χ::Character)
-Compute matrix projection associated to the irreducible character `χ`.
+    matrix_projection([hom::InducedActionHomomorphism, ]χ::Character{T})
+Compute matrix projection associated to character `χ`.
 
-If the homomorphism is not passed, the dimension `d` of the projection is
-derived from `conjugacy_classes(χ)`. E.g. if `conjugacy_classes(χ)` consist
-of permutations of degree `d` (i.e. acting naturally on the set `1:d`) the
-result will be a matrix of size `(d,d)`.
-
+Returned `M<:AbstractMatrix{T}` of size `(d, d)` where the degree `d` of the
+projecion is determined by elements in `conjugacy_classes(χ)`. E.g. `d` could
+be equal to the `degree` when conjugacy classes consist of `AbstractPerms`.
 If the homomorphism is passed, the dimension will be derived in similar
 manner from the elements of the image of the homomorphism.
+
+The precise type of `M` can be altered by overloading
+
+```
+preallocate(::Type{T}, [hom::InducedActionHomomorphism, ]χ::Character)
+```
 """
-function matrix_projection_irr(χ::Character)
-    @assert isirreducible(χ)
-    mproj = matrix_projection_irr(collect(values(χ)), conjugacy_classes(χ))
-    mproj .*= degree(χ) // sum(length, conjugacy_classes(χ)) # χ(1)/order(G)
+function matrix_projection(χ::Character{T}) where {T}
+    tbl = table(χ)
+    mproj = preallocate(T, χ)
+    for (c, ψ) in zip(constituents(χ), irreducible_characters(T, tbl))
+        iszero(c) && continue
+        mproj .= c .* matrix_projection_irr_acc!(mproj, ψ)
+    end
     return mproj
 end
 
+function matrix_projection(
+    hom::InducedActionHomomorphism,
+    χ::Character{T},
+) where {T}
+    tbl = table(χ)
+    mproj = preallocate(T, hom, χ)
+
+    for (c, ψ) in zip(constituents(χ), irreducible_characters(T, tbl))
+        iszero(c) && continue
+        mproj .= c .* matrix_projection_irr_acc!(mproj, hom, ψ)
+    end
+    return mproj
+end
+
+"""
+    matrix_projection_irr(χ::Character)
+    matrix_projection_irr([::Type, hom::InducedActionHomomorphism, ]χ::Character)
+Compute matrix projection associated to an *irreducible* character `χ`.
+
+The returned matrix defines so called *isotypical* projection.
+
+See also [matrix_projection](@ref).
+"""
+matrix_projection_irr(χ::Character{T}) where {T} = matrix_projection_irr(T, χ)
+
+matrix_projection_irr(::Type{T}, χ::Character) where {T} =
+    matrix_projection_irr_acc!(preallocate(T, χ), χ)
+
 function matrix_projection_irr(
+    hom::InducedActionHomomorphism,
+    χ::Character{T},
+) where {T}
+    return matrix_projection_irr(T, hom, χ)
+end
+
+function matrix_projection_irr(
+    ::Type{T},
+    hom::InducedActionHomomorphism,
+    χ::Character,
+) where {T}
+    return matrix_projection_irr_acc!(preallocate(T, hom, χ), hom, χ)
+end
+
+function matrix_projection_irr_acc!(result::AbstractMatrix, χ::Character)
+    @assert isirreducible(χ)
+    LinearAlgebra.checksquare(result)
+    ccls = conjugacy_classes(χ)
+    vals = collect(values(χ))
+    result .= matrix_projection_irr_acc!(result, vals, ccls)
+    result .*= degree(χ) // sum(length, ccls)
+    return result
+end
+
+function matrix_projection_irr_acc!(
+    result::AbstractMatrix,
     vals,
     ccls::AbstractVector{<:AbstractOrbit{<:PermutationGroups.AbstractPerm}},
-)
-    dim = degree(first(first(ccls)))
-    result = zeros(eltype(vals), dim, dim)
-
+) where {T}
     for (val, cc) in zip(vals, ccls)
         for g in cc
-            for i in 1:dim
+            for i in 1:size(result, 1)
                 result[i, i^g] += val
             end
         end
@@ -35,44 +132,46 @@ function matrix_projection_irr(
     return result
 end
 
-function matrix_projection_irr(
+function matrix_projection_irr_acc!(
+    result::AbstractMatrix,
     vals,
     ccls::AbstractVector{<:AbstractOrbit{<:AbstractMatrix}},
 )
     # TODO: call to inv(Matrix(g)) is a dirty hack, since if `g`
     # is given by a sparse matrix `inv(g)` will fail.
-    return sum(val .* sum(g -> inv(Matrix(g)), cc) for (val, cc) in zip(vals, ccls))
-end
-
-function matrix_projection(χ::Character{T}) where T
-    tbl = table(χ)
-    res = sum(
-        c .* matrix_projection_irr(ψ)
-        for (c, ψ) in zip(constituents(χ), irreducible_characters(T, tbl)) if !iszero(c)
-    )
+    for (val, cc) in zip(vals, ccls)
+        for g in cc
+            res .+= val .* inv(convert(Matrix, g))
+        end
+    end
     return res
 end
 
-## versions with InducedActionHomomorphisms
-
-function matrix_projection_irr(hom::InducedActionHomomorphism, χ::Character{T}) where T
+function matrix_projection_irr_acc!(
+    result::AbstractMatrix,
+    hom::InducedActionHomomorphism,
+    χ::Character,
+)
     @assert isirreducible(χ)
-    mproj = matrix_projection_irr(hom, collect(values(χ)), conjugacy_classes(χ))
-    mproj .*= degree(χ) // sum(length, conjugacy_classes(χ)) # χ(1)/order(G)
-    return eltype(mproj) == T ? mproj : T.(mproj)
+    LinearAlgebra.checksquare(result)
+    ccls = conjugacy_classes(χ)
+    vals = collect(values(χ))
+    result .= matrix_projection_irr_acc!(result, hom, vals, ccls)
+    result .*= degree(χ) // sum(length, ccls)
+    return result
 end
 
-function matrix_projection_irr(
+function matrix_projection_irr_acc!(
+    result::AbstractMatrix,
     hom::InducedActionHomomorphism{<:ByPermutations},
     class_values,
     conjugacy_cls,
-    )
-    dim = degree(induce(hom, first(first(conjugacy_cls))))
-    result = zeros(eltype(class_values), dim, dim)
+)
     for (val, ccl) in zip(class_values, conjugacy_cls)
         for g in ccl
             h = induce(hom, g)
-            for i in 1:dim
+            @assert h isa PermutationGroups.Perm
+            for i in 1:size(result, 1)
                 result[i, i^h] += val
             end
         end
@@ -80,94 +179,134 @@ function matrix_projection_irr(
     return result
 end
 
-function matrix_projection_irr(
+function matrix_projection_irr_acc!(
+    result::AbstractMatrix,
     hom::InducedActionHomomorphism{<:ByLinearTransformation},
     class_values,
     conjugacy_cls,
 )
-    return sum(
-        val .* sum(g -> induce(hom, inv(g)), cc)
-        for (val, cc) in zip(class_values, conjugacy_cls)
-    )
+    for (val, cc) in zip(class_values, conjugacy_cls)
+        iszero(val) && continue
+        for g in cc
+            result .+= val .* induce(hom, inv(g))
+        end
+    end
+    return result
 end
 
-function matrix_projection(hom::InducedActionHomomorphism, χ::Character{T}) where T
-    irr = irreducible_characters(T, table(χ))
-    cnsttnts = constituents(χ)
+"""
+    matrix_representation([::Type{T}, ]α::AlgebraElement)
+    matrix_representation([::Type{T}, ]hom::InducedActionHomomorphism, α::AlgebraElement)
+Compute matrix representative of the given algebra element `α`.
 
-    res = sum(
-        c .* matrix_projection_irr(hom, ψ)
-        for (c, ψ) in zip(cnsttnts, irr) if !iszero(c)
-    )
-    return res
+If `α` is an element of the group (or monoid) algebra `RG` of `G`, then every
+linear representation `π : G → GL(V)` gives rise to an algebra homomorphism
+`π : RG → B(V)` (bounded operators on `V`). This function evaluates this
+representation given either by
+ * the natural action of `G` on some `V` (e.g. every permutation group of degree
+ `d` acts on `d`-dimensional `V` by basis vector permutation), or
+ * by action homomorphism `hom`.
+
+See also [matrix_projection](@ref).
+"""
+matrix_representation(α::AlgebraElement) = matrix_representation(eltype(α), α)
+matrix_representation(::Type{T}, α::AlgebraElement) where {T} =
+    matrix_representation_acc!(preallocate(T, α), α)
+matrix_representation(hom::InducedActionHomomorphism, α::AlgebraElement) =
+    matrix_representation(eltype(α), hom, α)
+
+function matrix_representation(
+    ::Type{T},
+    hom::InducedActionHomomorphism,
+    α::AlgebraElement,
+) where {T}
+    return matrix_representation_acc!(preallocate(T, hom, α), hom, α)
 end
 
-function matrix_projection(
+function matrix_representation_acc!(
+    result::AbstractMatrix,
+    α::AlgebraElement{
+        <:StarAlgebra{<:PermutationGroups.AbstractPermutationGroup},
+    },
+)
+    b = basis(parent(α))
+    for (idx, val) in StarAlgebras._nzpairs(StarAlgebras.coeffs(α))
+        g = b[idx]
+        for i in 1:size(result, 1)
+            result[i, i^g] += val
+        end
+    end
+
+    return result
+end
+
+function matrix_representation_acc!(
+    result::AbstractMatrix,
     hom::InducedActionHomomorphism{<:ByPermutations},
     α::AlgebraElement,
-    dim::Integer = length(basis(hom)),
 )
-    result = zeros(eltype(α), dim, dim)
     b = basis(parent(α))
-
-    @inbounds for (j, a) in StarAlgebras._nzpairs(StarAlgebras.coeffs(α))
-        g = induce(hom, b[j])
-        for i in 1:dim
-            result[i, i^g] += a
+    for (idx, val) in StarAlgebras._nzpairs(StarAlgebras.coeffs(α))
+        g = induce(hom, b[idx])
+        @assert g isa PermutationGroups.Perm
+        for i in 1:size(result, 1)
+            result[i, i^g] += val
         end
     end
 
     return result
 end
 
-function matrix_projection(
+function matrix_representation_acc!(
+    result::AbstractMatrix,
     hom::InducedActionHomomorphism{<:ByLinearTransformation},
     α::AlgebraElement,
-    dim::Integer = length(basis(hom)),
 )
-
-    result = zeros(Base._return_type(*, Tuple{eltype(α), coeff_type(action(hom))}), dim, dim)
     b = basis(parent(α))
-
-    for (j, a) in StarAlgebras._nzpairs(StarAlgebras.coeffs(α))
-        result += a*induce(hom, inv(b[j]))
+    for (idx, val) in StarAlgebras._nzpairs(StarAlgebras.coeffs(α))
+        result .+= val .* induce(hom, inv(b[idx]))
     end
 
     return result
 end
 
-function matrix_projection(
-    α::AlgebraElement{<:StarAlgebra{<:PermutationGroups.AbstractPermutationGroup}},
-    dim::Integer = degree(parent(parent(α)))
-)
-    result = zeros(eltype(α), dim, dim)
-    b = basis(parent(α))
+## Finding basis of the row-space (right image) of an AbstractMatrix
 
-    @inbounds for (j, a) in StarAlgebras._nzpairs(StarAlgebras.coeffs(α))
-        g = b[j]
-        for i in 1:dim
-            result[i, i^g] += a
-        end
-    end
+"""
+    image_basis(A::AbstractMatrix)
+    image_basis([hom::InducedActionHomomorphism, ]χ::Character)
+    image_basis([hom::InducedActionHomomorphism, ]α::AlgebraElement)
+Return basis of the row-space of a matrix.
 
-    return result
-end
+For characters or algebra elements return a basis of the row-space of
+`matrix_projection([hom, ]χ)` or `matrix_representation([hom, ]α)`.
 
-image_basis!(A::AbstractMatrix) = row_echelon_form!(A)
+Two methods are employed to achieve the goal.
+* By default (symbolic, exact) row echelon form is produced, and therefore there is no guarantee on the orthogonality of the returned basis vectors (rows).
+* If `eltype(A) <: AbstractFloat` this is followed by a call to `svd` and the appropriate rows of its `Vt` are returned, thus the basis is (numerically) orthonormal.
 
-function image_basis!(A::AbstractMatrix{T}) where {T<:AbstractFloat}
-    A, p = row_echelon_form!(A)
-    fact = svd!(Matrix(@view A[1:length(p), :]))
-    A_rank = sum(fact.S .> maximum(size(A)) * eps(T))
-    return fact.Vt, 1:A_rank
-end
+# Examples:
+```julia
+julia> a = rand(-3:3, 3,3).//rand(1:4, 3,3);
 
-function image_basis!(A::AbstractMatrix{T}) where {T<:Complex}
-    fact = svd!(A)
-    A_rank = sum(fact.S .> maximum(size(A)) * 2eps(real(T)))
-    return fact.Vt, 1:A_rank
-end
+julia> a[3, :] .= 2a[1, :] .- 1a[2, :]; a
+3×3 Matrix{Rational{Int64}}:
+  3//2   0//1  1//1
+ -1//2  -2//1  1//2
+  7//2   2//1  3//2
 
+julia> ib = SymbolicWedderburn.image_basis(a)
+2×3 Matrix{Rational{Int64}}:
+ 1//1  0//1   2//3
+ 0//1  1//1  -5//12
+
+julia> ibf = SymbolicWedderburn.image_basis(float.(a))
+2×3 Matrix{Float64}:
+ -0.666651  0.416657  -0.618041
+  0.529999  0.847998  -8.85356e-17
+
+```
+"""
 image_basis(A::AbstractMatrix) =
     ((m, p) = image_basis!(deepcopy(A)); m[1:length(p), :])
 
@@ -178,17 +317,35 @@ function image_basis(χ::Character)
 end
 
 function image_basis(hom::InducedActionHomomorphism, χ::Character)
-    mpr = isirreducible(χ) ? matrix_projection_irr(hom, χ) : matrix_projection(hom, χ)
+    mpr =
+        isirreducible(χ) ? matrix_projection_irr(hom, χ) :
+        matrix_projection(hom, χ)
     image, pivots = image_basis!(mpr)
     return image[1:length(pivots), :]
 end
 
 function image_basis(α::AlgebraElement)
-    image, pivots = image_basis!(matrix_projection(α))
+    image, pivots = image_basis!(matrix_representation(α))
     return image[1:length(pivots), :]
 end
 
 function image_basis(hom::InducedActionHomomorphism, α::AlgebraElement)
-    image, pivots = image_basis!(matrix_projection(hom, α))
+    image, pivots = image_basis!(matrix_representation(hom, α))
     return image[1:length(pivots), :]
+end
+
+image_basis!(A::AbstractMatrix) = row_echelon_form!(A)
+
+function image_basis!(A::AbstractMatrix{T}) where {T<:AbstractFloat}
+    A, p = row_echelon_form!(A)
+    fact = svd!(convert(Matrix{T}, @view(A[1:length(p), :])))
+    A_rank = sum(fact.S .> maximum(size(A)) * eps(T))
+    @assert A_rank == length(p)
+    return fact.Vt, 1:length(p)
+end
+
+function image_basis!(A::AbstractMatrix{T}) where {T<:Complex}
+    fact = svd!(A)
+    A_rank = sum(fact.S .> maximum(size(A)) * 2eps(real(T)))
+    return fact.Vt, 1:A_rank
 end

--- a/src/matrix_projections.jl
+++ b/src/matrix_projections.jl
@@ -44,6 +44,15 @@ function matrix_projection_irr(
     return sum(val .* sum(g -> inv(Matrix(g)), cc) for (val, cc) in zip(vals, ccls))
 end
 
+function matrix_projection(χ::Character{T}) where T
+    tbl = table(χ)
+    res = sum(
+        c .* matrix_projection_irr(ψ)
+        for (c, ψ) in zip(constituents(χ), irreducible_characters(T, tbl)) if !iszero(c)
+    )
+    return res
+end
+
 ## versions with InducedActionHomomorphisms
 
 function matrix_projection_irr(hom::InducedActionHomomorphism, χ::Character{T}) where T
@@ -82,22 +91,15 @@ function matrix_projection_irr(
     )
 end
 
-function matrix_projection(χ::Character{T}) where T
-    tbl = table(χ)
-    res = sum(
-        c .* matrix_projection_irr(ψ)
-        for (c, ψ) in zip(constituents(χ), irreducible_characters(tbl)) if !iszero(c)
-    )
-    return eltype(res) == T ? res : T.(res)
-end
-
 function matrix_projection(hom::InducedActionHomomorphism, χ::Character{T}) where T
-    tbl = table(χ)
+    irr = irreducible_characters(T, table(χ))
+    cnsttnts = constituents(χ)
+
     res = sum(
         c .* matrix_projection_irr(hom, ψ)
-        for (c, ψ) in zip(constituents(χ), irreducible_characters(tbl)) if !iszero(c)
+        for (c, ψ) in zip(cnsttnts, irr) if !iszero(c)
     )
-    return eltype(res) == T ? res : T.(res)
+    return res
 end
 
 function matrix_projection(

--- a/src/matrix_projections.jl
+++ b/src/matrix_projections.jl
@@ -29,7 +29,7 @@ function preallocate(
     hom::InducedActionHomomorphism,
     χ::Union{Character,AlgebraElement},
 )
-    T = promote_type(coeff_type(hom), eltype(χ))
+    T = Base._return_type(*, (coeff_type(hom), eltype(χ)))
     return preallocate(T, hom, χ)
 end
 

--- a/src/matrix_projections.jl
+++ b/src/matrix_projections.jl
@@ -103,7 +103,7 @@ end
 function matrix_projection(
     hom::InducedActionHomomorphism{<:ByPermutations},
     α::AlgebraElement,
-    dim::Integer = length(features(hom)),
+    dim::Integer = length(basis(hom)),
 )
     result = zeros(eltype(α), dim, dim)
     b = basis(parent(α))
@@ -121,7 +121,7 @@ end
 function matrix_projection(
     hom::InducedActionHomomorphism{<:ByLinearTransformation},
     α::AlgebraElement,
-    dim::Integer = length(features(hom)),
+    dim::Integer = length(basis(hom)),
 )
 
     result = zeros(Base._return_type(*, Tuple{eltype(α), coeff_type(action(hom))}), dim, dim)

--- a/src/matrix_projections.jl
+++ b/src/matrix_projections.jl
@@ -164,10 +164,13 @@ function matrix_projection_irr_acc!(
     ccls::AbstractVector{<:AbstractOrbit{<:PermutationGroups.AbstractPerm}},
     weight,
 ) where {T}
+    iszero(weight) && return result
     for (val, cc) in zip(vals, ccls)
+        iszero(val) && continue
+        w = weight * val
         for g in cc
             for i in 1:size(result, 1)
-                result[i, i^g] += weight * val
+                result[i, i^g] += w
             end
         end
     end
@@ -184,6 +187,7 @@ function matrix_projection_irr_acc!(
     # TODO: call to inv(Matrix(g)) is a dirty hack, since if `g`
     # is given by a sparse matrix `inv(g)` will fail.
     for (val, cc) in zip(vals, ccls)
+        iszero(val) && continue
         for g in cc
             res .+= (weight * val) .* inv(convert(Matrix, g))
         end
@@ -213,12 +217,15 @@ function matrix_projection_irr_acc!(
     conjugacy_cls,
     weight,
 )
+    iszero(weight) && return result
     for (val, ccl) in zip(class_values, conjugacy_cls)
+        iszero(val) && continue
+        w = weight * val
         for g in ccl
             h = induce(hom, g)
             @assert h isa PermutationGroups.Perm
             for i in 1:size(result, 1)
-                result[i, i^h] += weight * val
+                result[i, i^h] += w
             end
         end
     end
@@ -232,10 +239,12 @@ function matrix_projection_irr_acc!(
     conjugacy_cls,
     weight,
 )
+    iszero(weight) && return result
     for (val, cc) in zip(class_values, conjugacy_cls)
         iszero(val) && continue
+        w = weight * val
         for g in cc
-            result .+= (weight * val) .* induce(hom, inv(g))
+            result .+= w .* induce(hom, inv(g))
         end
     end
     return result
@@ -272,6 +281,7 @@ function matrix_representation_acc!(
     b = basis(parent(α))
     for (idx, val) in StarAlgebras._nzpairs(StarAlgebras.coeffs(α))
         g = b[idx]
+        iszero(val) && continue
         for i in 1:size(result, 1)
             result[i, i^g] += val
         end
@@ -287,6 +297,7 @@ function matrix_representation_acc!(
 )
     b = basis(parent(α))
     for (idx, val) in StarAlgebras._nzpairs(StarAlgebras.coeffs(α))
+        iszero(val) && continue
         g = induce(hom, b[idx])
         @assert g isa PermutationGroups.Perm
         for i in 1:size(result, 1)
@@ -304,6 +315,7 @@ function matrix_representation_acc!(
 )
     b = basis(parent(α))
     for (idx, val) in StarAlgebras._nzpairs(StarAlgebras.coeffs(α))
+        iszero(val) && continue
         result .+= val .* induce(hom, inv(b[idx]))
     end
 

--- a/src/minimal_projections.jl
+++ b/src/minimal_projections.jl
@@ -83,18 +83,10 @@ function small_idempotents(
     return (algebra_elt_from_support(H, RG) // length(H) for H in subgroups)
 end
 
-@static if VERSION < v"1.3.0"
-    function (χ::Character)(α::AlgebraElement{<:StarAlgebra{<:Group}})
-        @assert parent(χ) === parent(parent(α))
-        iszero(α) && return zero(eltype(StarAlgebras.coeffs(α)))*zero(eltype(χ))
-        return sum(α(g) * χ(g) for g in supp(α))
-    end
-else
-    function (χ::AbstractClassFunction)(α::AlgebraElement{<:StarAlgebra{<:Group}})
-        @assert parent(χ) === parent(parent(α))
-        iszero(α) && return zero(eltype(StarAlgebras.coeffs(α)))*zero(eltype(χ))
-        return sum(α(g) * χ(g) for g in supp(α))
-    end
+function (χ::AbstractClassFunction)(α::AlgebraElement{<:StarAlgebra{<:Group}})
+    @assert parent(χ) === parent(parent(α))
+    iszero(α) && return zero(eltype(StarAlgebras.coeffs(α)))*zero(eltype(χ))
+    return sum(α(g) * χ(g) for g in supp(α))
 end
 
 function minimal_rank_projection(χ::Character, RG::StarAlgebra{<:Group};
@@ -121,7 +113,7 @@ function minimal_projection_system(
     chars::AbstractVector{<:AbstractClassFunction},
     RG::StarAlgebra{<:Group}
 )
-    res = fetch.([@spawn_compat minimal_rank_projection(χ, RG) for χ in chars])
+    res = fetch.([Threads.@spawn minimal_rank_projection(χ, RG) for χ in chars])
 
     r1p, simple = first.(res), last.(res) # rp1 are sparse storage
 

--- a/src/sa_basis.jl
+++ b/src/sa_basis.jl
@@ -145,8 +145,8 @@ function symmetry_adapted_basis(
     if T <: Real
         irr, multips = affordable_real(irr, multips)
         @debug "Decomposition into real character spaces:
-        degrees:        $(join([lpad(d, 6) for d in degrees], ""))
-        multiplicities: $(join([lpad(m, 6) for m in multiplicities], ""))"
+        degrees:        $(join([lpad(d, 6) for d in degree.(irr)], ""))
+        multiplicities: $(join([lpad(m, 6) for m in multips], ""))"
 
     end
 

--- a/src/sa_basis.jl
+++ b/src/sa_basis.jl
@@ -194,7 +194,7 @@ function _symmetry_adapted_basis(
     hom=nothing
 )
     res = map(zip(irr, multiplicities)) do (µ, m)
-        @spawn_compat begin
+        Threads.@spawn begin
             µT = eltype(µ) == T ? µ : Character{T}(µ)
             image = hom === nothing ? image_basis(µT) : image_basis(hom, µT)
             simple = size(image, 1) == m
@@ -219,7 +219,7 @@ function _symmetry_adapted_basis(
     mps, simples = minimal_projection_system(irr, RG)
     degrees = degree.(irr)
     res = map(zip(mps, multiplicities, degrees, simples)) do (µ, m, deg, simple)
-        @spawn_compat begin
+        Threads.@spawn begin
             µT = eltype(µ) == T ? µ : AlgebraElement{T}(µ)
             image = hom === nothing ? image_basis(µT) : image_basis(hom, µT)
             @assert size(image, 1) == (simple ? m : m*deg) "incompatible projection dimension: $(size(image, 1)) ≠ $(simple ? m : m*deg)"

--- a/src/sa_basis.jl
+++ b/src/sa_basis.jl
@@ -80,7 +80,7 @@ function symmetry_adapted_basis(
     semisimple::Bool = false,
 )
     irr, multips = _constituents_decomposition(
-        action_character(conjugacy_classes(tbl), tbl),
+        action_character(T, conjugacy_classes(tbl), tbl),
         tbl,
     )
 

--- a/src/wedderburn_decomposition.jl
+++ b/src/wedderburn_decomposition.jl
@@ -79,7 +79,7 @@ function diagonalize!(
     @assert length(Mπs) == length(Uπs)
 
     for (π, Uπ) in enumerate(Uπs)
-        imUπ = image_basis(Uπ) # Base.Matrix to allow BLAS paths below
+        imUπ = convert(Matrix, image_basis(Uπ)) # Base.Matrix to allow BLAS paths below
         LinearAlgebra.mul!(tmps[π], imUπ, M)
         LinearAlgebra.mul!(Mπs[π], tmps[π], imUπ')
         zerotol!(Mπs[π], atol = eps(eltype(imUπ)) * max(size(imUπ)...))

--- a/src/wedderburn_decomposition.jl
+++ b/src/wedderburn_decomposition.jl
@@ -101,3 +101,7 @@ function invariant_vectors(
     # change the format of invariant_vectors to image_basis(ehom, trχ)
     return sparsevec.(eachrow(image_basis(ehom, trχ)))
 end
+
+@static if VERSION < v"1.1"
+    eachrow(A::AbstractMatrix) = [A[i, :] for i in size(A, 1)]
+end

--- a/src/wedderburn_decomposition.jl
+++ b/src/wedderburn_decomposition.jl
@@ -101,7 +101,3 @@ function invariant_vectors(
     # change the format of invariant_vectors to image_basis(ehom, trχ)
     return sparsevec.(eachrow(image_basis(ehom, trχ)))
 end
-
-@static if VERSION < v"1.1"
-    eachrow(A::AbstractMatrix) = [A[i, :] for i in size(A, 1)]
-end

--- a/src/wedderburn_decomposition.jl
+++ b/src/wedderburn_decomposition.jl
@@ -93,10 +93,14 @@ function invariant_vectors(
     act::Action,
     basis::StarAlgebras.Basis,
 )
-    trχ = Characters.Character{Rational{Int}}(Characters.trivial_character(tbl))
+    triv_χ = Characters.Character{Rational{Int}}(Characters.trivial_character(tbl))
+    ehom =
+        CachedExtensionHomomorphism(parent(tbl), act, basis, precompute = true)
+    # ehom = ExtensionHomomorphism(act, basis)
 
-    ehom = ExtensionHomomorphism(act, basis)
-    img = image_basis(ehom, trχ)
+    mpr = matrix_projection_irr(ehom, triv_χ)
+    mpr, pivots = row_echelon_form!(mpr)
+    img = mpr[1:length(pivots), :]
 
     # change the format of invariant_vectors to image_basis(ehom, trχ)
     return sparsevec.(eachrow(img))

--- a/src/wedderburn_decomposition.jl
+++ b/src/wedderburn_decomposition.jl
@@ -17,12 +17,10 @@ function WedderburnDecomposition(
     tbl = CharacterTable(S, G)
     ehom = CachedExtensionHomomorphism(G, action, basis_half, precompute = true)
 
-    Uπs = let
-        sa_basis = symmetry_adapted_basis(T, tbl, ehom; semisimple = semisimple)
-    end
+    Uπs = symmetry_adapted_basis(T, tbl, ehom; semisimple = semisimple)
 
     basis = StarAlgebras.Basis{UInt32}(basis_full)
-    invariants = invariant_vectors(tbl, action, basis_full)
+    invariants = invariant_vectors(tbl, action, basis)
 
     return WedderburnDecomposition(basis, invariants, Uπs, ehom)
 end
@@ -93,11 +91,14 @@ end
 function invariant_vectors(
     tbl::Characters.CharacterTable,
     act::Action,
-    basis
+    basis::StarAlgebras.Basis
 )
     trχ = Characters.Character{Rational{Int}}(Characters.trivial_character(tbl))
-    ehom = CachedExtensionHomomorphism(parent(tbl), act, basis, precompute = true)
+
+    ehom = ExtensionHomomorphism(act, basis)
+    img = image_basis(ehom, trχ)
 
     # change the format of invariant_vectors to image_basis(ehom, trχ)
-    return sparsevec.(eachrow(image_basis(ehom, trχ)))
+    return sparsevec.(eachrow(img))
+end
 end

--- a/test/action_dihedral.jl
+++ b/test/action_dihedral.jl
@@ -15,7 +15,7 @@ const OPTIMIZER = optimizer_with_attributes(
     SCS.Optimizer,
     "acceleration_lookback" => 10,
     "max_iters" => 3_000,
-    "alpha" => 1.5,
+    "alpha" => 1.2,
     "eps" => 1e-6,
     "linear_solver" => SCS.DirectSolver,
 )
@@ -90,5 +90,6 @@ end
     optimize!(m)
 
     @test isapprox(value(m[:t]), -3825 / 4096, rtol = 1e-4)
-    @test termination_status(m) == MOI.OPTIMAL
+    status = termination_status(m)
+    @test status ∈ (MOI.OPTIMAL, MOI.ALMOST_OPTIMAL)
 end

--- a/test/action_linear.jl
+++ b/test/action_linear.jl
@@ -15,7 +15,7 @@ function SymbolicWedderburn.action(::By90Rotation, g::CyclicGroupElement, m::Mon
 end
 
 function SymbolicWedderburn.decompose(k::AbstractPolynomial, hom::SymbolicWedderburn.InducedActionHomomorphism)
-    # correct only if features(hom) == monomials
+    # correct only if basis(hom) == monomials
 
     indcs = [hom[m] for m in monomials(k)]
     coeffs = coefficients(k)

--- a/test/action_permutation.jl
+++ b/test/action_permutation.jl
@@ -18,14 +18,14 @@ function SymbolicWedderburn.action(::OnLetters, p::PermutationGroups.AbstractPer
 end
 
 @testset "Extending homomorphism" begin
-    words = let A = [:a, :b, :c]
+    words = let A = [:a, :b, :c], radius = 4
         w = Word(A, [1,2,3,2,1])
 
         # (a·b·c·b·a)^(2,3) == a·c·b·c·a
         @test SymbolicWedderburn.action(OnLetters(), perm"(2,3)", w) == Word(A, [1,3,2,3,1])
 
         words = [Word(A, [1]), Word(A, [2]), Word(A, [3])]
-        for r in 2:4
+        for r in 2:radius
             append!(
                 words,
                 [Word(A, collect(w)) for w in Iterators.product(fill(1:3, r)...)]
@@ -48,6 +48,10 @@ end
     @test dot(SymbolicWedderburn.degree.(irr), multips) == length(basis)
     simple = isone.(SymbolicWedderburn.degree.(irr))
     @test simple == [false, true, true]
+
+    inv_vec = SymbolicWedderburn.invariant_vectors(tbl, action, SymbolicWedderburn.basis(ehom))
+    @test length(inv_vec) == 22
+    @test eltype(inv_vec) == SparseVector{Rational{Int}}
 
     @testset "semisimple decomposition" begin
         let i = 1

--- a/test/action_permutation.jl
+++ b/test/action_permutation.jl
@@ -101,17 +101,17 @@ end
 
             µ = AlgebraElement(χ, RG)*a
             mpr = SymbolicWedderburn.image_basis(ehom, µ)
-            @test mpr isa Matrix{eltype(µ)}
+            @test mpr isa AbstractMatrix{eltype(µ)}
             @test size(mpr, 1) == m
 
             µR = AlgebraElement{Rational{Int}}(µ)
             mpr = SymbolicWedderburn.image_basis(ehom, µR)
-            @test mpr isa Matrix{eltype(µR)}
+            @test mpr isa AbstractMatrix{eltype(µR)}
             @test size(mpr, 1) == m
 
             µFl = AlgebraElement{Float64}(µ)
             mpr = SymbolicWedderburn.image_basis(ehom, µFl)
-            @test mpr isa Matrix{eltype(µFl)}
+            @test mpr isa AbstractMatrix{eltype(µFl)}
             @test size(mpr, 1) == m
         end
 
@@ -121,7 +121,7 @@ end
 
             µ = AlgebraElement(χ, RG)*a
             mpr = SymbolicWedderburn.image_basis(ehom, µ)
-            @test mpr isa Matrix{eltype(µ)}
+            @test mpr isa AbstractMatrix{eltype(µ)}
             @test size(mpr, 1) == m
         end
 
@@ -131,7 +131,7 @@ end
 
             µ = AlgebraElement(χ, RG)*a
             mpr = SymbolicWedderburn.image_basis(ehom, µ)
-            @test mpr isa Matrix{eltype(µ)}
+            @test mpr isa AbstractMatrix{eltype(µ)}
             @test size(mpr, 1) == m
         end
 

--- a/test/characters.jl
+++ b/test/characters.jl
@@ -53,6 +53,6 @@ end
 
     if VERSION > v"1.3.0"
         @test sprint(show, MIME"text/plain"(), chars[1]) ==
-        "Character over Cyclotomic{Rational{Int64}, SparseArrays.SparseVector{Rational{Int64}, Int64}}\nχ₁"
+        "Character over Cyclotomic{Rational{Int64}, SparseVector{Rational{Int64}, Int64}}\nχ₁"
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using LinearAlgebra
 using GroupsCore
 using PermutationGroups
 using Cyclotomics
+using SparseArrays
 
 include("smallgroups.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,12 +27,6 @@ include("action_dihedral.jl")
 
 if VERSION >= v"1.7.0" && !haskey(ENV, "CI")
     @testset "Examples" begin
-        using Pkg
-        Pkg.activate(joinpath(@__DIR__, "..", "examples"))
-        Pkg.instantiate()
-        include("../examples/ex_C2_linear.jl")
-        include("../examples/ex_S4.jl")
-        include("../examples/ex_motzkin.jl")
-        include("../examples/ex_robinson_form.jl")
+        include("../examples/run_examples.jl")
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ include("action_permutation.jl")
 include("action_linear.jl")
 include("action_dihedral.jl")
 
-if VERSION >= v"1.6.0" && !haskey(ENV, "CI")
+if VERSION >= v"1.7.0" && !haskey(ENV, "CI")
     @testset "Examples" begin
         using Pkg
         Pkg.activate(joinpath(@__DIR__, "..", "examples"))

--- a/test/sa_basis.jl
+++ b/test/sa_basis.jl
@@ -46,7 +46,7 @@ end
         @test all(simple)
 
         @test rank(float.(SymbolicWedderburn.matrix_projection(irr[1]))) == 2
-        @test rank(float.(SymbolicWedderburn.matrix_projection(mps[1]))) == 1
+        @test rank(float.(SymbolicWedderburn.matrix_representation(mps[1]))) == 1
 
         sa_basis_ssimple = symmetry_adapted_basis(Rational{Int}, G, Rational{Int}, semisimple=true)
 
@@ -103,7 +103,7 @@ end
 
                     @test sum(first ∘ size, sa_basis) == PermutationGroups.degree(G)
 
-                    S = if (ord, n) in ((21,1),)
+                    S = if (ord, n) in ((26,1),)
                         Rational{BigInt}
                     else
                         Rational{Int}


### PR DESCRIPTION
this gets rid of numerical linear algebra computations for invariant vectors using the technology we've already had: projections in the group ring.

`invariant_vectors` constitute basis for the space of `G`-invariant vectors `⟨basis_full⟩^G`, hence their computation is the same as finding `image_basis` for the projection defined by the trivial character. If action is by permutation orbits are disjoint, hence orthogonal. Otherwise we call single `svd` at the end to orthogonalize the whole basis. Bonus: no zero vectors sneak in ;)  

a baby example with `length(basis_full)=370` and `order(G) = 48` gives:
```julia
# before
@btime invariant_vectors(H, act, basis_full);
117.466 ms (594156 allocations: 120.26 MiB)
# after
tbl = CharacterTable(Rational{Int}, H) # we compute tbl in WedderburnDecomposition anyway
@btime invariant_vectors(tbl, act, basis_full);
 33.763 ms (537076 allocations: 30.36 MiB)
```

CC: @thinh-le