### PR TITLE
don't assume R-module structure on basis (as a set)

### DIFF
--- a/src/group_action_error.jl
+++ b/src/group_action_error.jl
@@ -92,7 +92,7 @@ function __group_action_right_assoc(
     xᵍꜝʰ, s_g_h = action(action(hom), h, xᵍ)
 
     passed = s_gh == s_g * s_g_h && xᵍʰ == xᵍꜝʰ
-    return passed, s_gh * xᵍʰ, (s_g * s_g_h) * xᵍꜝʰ
+    return passed, (s_gh,  xᵍʰ), (s_g * s_g_h, xᵍꜝʰ)
 end
 
 function __group_action_right_assoc(

--- a/test/action_permutation.jl
+++ b/test/action_permutation.jl
@@ -26,12 +26,24 @@ function SymbolicWedderburn.action(
     return Word(w.alphabet, [w.letters[i]^p for i in eachindex(w.letters)])
 end
 
+struct OnLettersSigned <: SymbolicWedderburn.BySignedPermutations end
+function SymbolicWedderburn.action(
+    ::OnLettersSigned,
+    p::PermutationGroups.AbstractPermutation,
+    w::Word,
+)
+    return (Word(w.alphabet, [w.letters[i]^p for i in eachindex(w.letters)]), 1)
+end
+
 function allwords(A, radius)
     words = [Word(A, [i]) for i in 1:length(A)]
     for r in 2:radius
         append!(
             words,
-            [Word(A, collect(w)) for w in Iterators.product(fill(1:3, r)...)],
+            [
+                Word(A, collect(w)) for
+                w in Iterators.product(fill(1:length(A), r)...)
+            ],
         )
     end
     return words
@@ -49,6 +61,10 @@ end
     end
 
     G = PermGroup(perm"(1,2,3)", perm"(1,2)") # G acts on words permuting letters
+
+    @test SymbolicWedderburn.check_group_action(G, OnLetters(), words)
+    @test SymbolicWedderburn.check_group_action(G, OnLettersSigned(), words)
+
     action = OnLetters()
     tbl = SymbolicWedderburn.CharacterTable(Rational{Int}, G)
     ehom = SymbolicWedderburn.CachedExtensionHomomorphism(


### PR DESCRIPTION
Setup:

```julia
G = PermGroup(perm"(1,2,3,4,5)", perm"(1,2)")
struct OnLettersSigned <: SymbolicWedderburn.BySignedPermutations end

function SymbolicWedderburn.action(
           ::OnLettersSigned,
           p::PermutationGroups.AbstractPermutation,
           w::Word
       )
    return (Word(w.alphabet, [w.letters[i]^p for i in eachindex(w.letters)]),1)
end
action = OnLettersSigned()
words = let A = [:a, :b, :c, :d, :e], radius = 2
    allwords(A, radius)
end
```

Before:
```julia
julia> sabasis = SymbolicWedderburn.symmetry_adapted_basis(G, action, words)

ERROR: MethodError: no method matching *(::Int64, ::Word{Symbol})

Closest candidates are:
  *(::Any, ::Any, ::Any, ::Any...)
   @ Base operators.jl:578
  *(::T, ::T) where T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}
   @ Base int.jl:88
  *(::Union{Int16, Int32, Int64, Int8}, ::BigInt)
   @ Base gmp.jl:552
  ...

Stacktrace:
 [1] __group_action_right_assoc(hom::SymbolicWedderburn.CachedExtensionHomomorphism{OnLetters, Word{Symbol}, Permutation{Perm{UInt16}, PermGroup{Perm{UInt16}, …}}, SparseArrays.SparseMatrixCSC{Int64, Int64}, SymbolicWedderburn.ExtensionHomomorphism{OnLetters, Word{Symbol}, StarAlgebras.Basis{Word{Symbol}, UInt16, Vector{Word{Symbol}}}}}, g::Permutation{Perm{UInt16}, PermGroup{Perm{UInt16}, …}}, h::Permutation{Perm{UInt16}, PermGroup{Perm{UInt16}, …}}, x::Word{Symbol})
   @ SymbolicWedderburn ~/.julia/dev/SymbolicWedderburn/src/group_action_error.jl:95
 [2] __check_group_action_axioms(itr::Vector{Permutation{Perm{UInt16}, PermGroup{Perm{UInt16}, …}}}, hom::SymbolicWedderburn.CachedExtensionHomomorphism{OnLetters, Word{Symbol}, Permutation{Perm{UInt16}, PermGroup{Perm{UInt16}, …}}, SparseArrays.SparseMatrixCSC{Int64, Int64}, SymbolicWedderburn.ExtensionHomomorphism{OnLetters, Word{Symbol}, StarAlgebras.Basis{Word{Symbol}, UInt16, Vector{Word{Symbol}}}}}, elts_idcs::UnitRange{Int64})
   @ SymbolicWedderburn ~/.julia/dev/SymbolicWedderburn/src/group_action_error.jl:142
 [3] #check_group_action#11
   @ ~/.julia/dev/SymbolicWedderburn/src/group_action_error.jl:166 [inlined]
 [4] check_group_action
   @ ~/.julia/dev/SymbolicWedderburn/src/group_action_error.jl:158 [inlined]
 [5] symmetry_adapted_basis(G::PermGroup{Perm{UInt16}, …}, action::OnLetters, basis::Vector{Word{Symbol}}, S::Type; semisimple::Bool)
   @ SymbolicWedderburn ~/.julia/dev/SymbolicWedderburn/src/sa_basis.jl:146
 [6] symmetry_adapted_basis
   @ ~/.julia/dev/SymbolicWedderburn/src/sa_basis.jl:132 [inlined]
 [7] symmetry_adapted_basis(G::PermGroup{Perm{UInt16}, …}, action::OnLetters, basis::Vector{Word{Symbol}})
   @ SymbolicWedderburn ~/.julia/dev/SymbolicWedderburn/src/sa_basis.jl:132
 [8] top-level scope
   @ REPL[52]:1

```

after:
```julia
julia> SW.check_group_action(G, action, words)
true
```





CC: @laurentbartholdi

