### PR TITLE
allow specifying index type for CachedExtensionHomomorphism

### DIFF
--- a/src/ext_homomorphisms.jl
+++ b/src/ext_homomorphisms.jl
@@ -17,11 +17,14 @@ PermutationGroups.degree(hom::InducedActionHomomorphism) = length(basis(hom))
 
 coeff_type(hom::InducedActionHomomorphism) = coeff_type(action(hom))
 _int_type(::Type{<:StarAlgebras.AbstractBasis{T,I}}) where {T,I} = I
-_int_type(hom::InducedActionHomomorphism) = _int_type(typeof(basis(hom)))
+_int_type(basis::StarAlgebras.AbstractBasis) = _int_type(typeof(basis))
+_int_type(hom::InducedActionHomomorphism) = _int_type(basis(hom))
 
-# Exceeding typemax(UInt16) here would mean e.g. that you're trying to block-diagonalize
-# an SDP constraint of size 65535×65535, which is highly unlikely ;)
-_int_type(::Type{<:InducedActionHomomorphism}) = UInt16
+# Exceeding typemax(UInt32) here would mean e.g. that you're trying to block-diagonalize
+# an SDP constraint of size 4_294_967_295 × 4_294_967_295, which is highly unlikely ;)
+_int_type(::Type{<:Action}) = UInt32
+_int_type(ac::Action) = _int_type(typeof(ac))
+
 
 function induce(hom::InducedActionHomomorphism, g::GroupElement)
     return induce(action(hom), hom, g)
@@ -43,7 +46,7 @@ end
 
 function ExtensionHomomorphism(action::Action, basis)
     return ExtensionHomomorphism(
-        _int_type(ExtensionHomomorphism),
+        _int_type(action),
         action,
         basis,
     )
@@ -104,7 +107,7 @@ function CachedExtensionHomomorphism(
     precompute = false,
 )
     return CachedExtensionHomomorphism(
-        _int_type(ExtensionHomomorphism),
+        _int_type(action),
         G,
         action,
         basis;

--- a/src/ext_homomorphisms.jl
+++ b/src/ext_homomorphisms.jl
@@ -78,12 +78,13 @@ StarAlgebras.basis(h::CachedExtensionHomomorphism) = basis(h.ehom)
 action(h::CachedExtensionHomomorphism) = action(h.ehom)
 
 function CachedExtensionHomomorphism(
+    ::Type{I},
     G::Group,
     action::Action,
     basis;
     precompute = false,
-)
-    hom = ExtensionHomomorphism(action, basis)
+) where {I}
+    hom = ExtensionHomomorphism(I, action, basis)
     S = typeof(induce(hom, one(G)))
     chom = CachedExtensionHomomorphism{eltype(G),S}(hom)
     @sync if precompute
@@ -94,6 +95,21 @@ function CachedExtensionHomomorphism(
         end
     end
     return chom
+end
+
+function CachedExtensionHomomorphism(
+    G::Group,
+    action::Action,
+    basis;
+    precompute = false,
+)
+    return CachedExtensionHomomorphism(
+        _int_type(ExtensionHomomorphism),
+        G,
+        action,
+        basis;
+        precompute = precompute,
+    )
 end
 
 function induce(ac::Action, chom::CachedExtensionHomomorphism, g::GroupElement)

--- a/test/action_permutation.jl
+++ b/test/action_permutation.jl
@@ -68,7 +68,7 @@ end
         precompute = true,
     )
     @test all(g ∈ keys(ehom.cache) for g in G) # we actually cached
-    @test typeof(SymbolicWedderburn.induce(ehom, one(G))) == Perm{UInt16}
+    @test typeof(SymbolicWedderburn.induce(ehom, one(G))) == Perm{UInt32} # the default
 
     ψ = SymbolicWedderburn.action_character(ehom, tbl)
     @test SymbolicWedderburn.constituents(ψ) == [40, 22, 18]

--- a/test/action_permutation.jl
+++ b/test/action_permutation.jl
@@ -52,12 +52,23 @@ end
     action = OnLetters()
     tbl = SymbolicWedderburn.CharacterTable(Rational{Int}, G)
     ehom = SymbolicWedderburn.CachedExtensionHomomorphism(
+        Int32,
         G,
         action,
         words;
         precompute = true,
     )
     @test all(g ∈ keys(ehom.cache) for g in G) # we actually cached
+    @test typeof(SymbolicWedderburn.induce(ehom, one(G))) == Perm{Int32}
+
+    ehom = SymbolicWedderburn.CachedExtensionHomomorphism(
+        G,
+        action,
+        words;
+        precompute = true,
+    )
+    @test all(g ∈ keys(ehom.cache) for g in G) # we actually cached
+    @test typeof(SymbolicWedderburn.induce(ehom, one(G))) == Perm{UInt16}
 
     ψ = SymbolicWedderburn.action_character(ehom, tbl)
     @test SymbolicWedderburn.constituents(ψ) == [40, 22, 18]


### PR DESCRIPTION
Problem:
No way to create `CachedExtensionHomomorphism` with specified index type. For large basis this could lead to hard to fix errors (without diving deep into the package).

Before:
```julia
julia> ehom = SymbolicWedderburn.CachedExtensionHomomorphism(G,action,words)
ERROR: "index type UInt16 is to small for basis of length 88572"
Stacktrace:
 [1] Basis
   @ ~/.julia/packages/StarAlgebras/0yFWh/src/bases.jl:9 [inlined]
 [2] ExtensionHomomorphism
   @ ~/.julia/dev/SymbolicWedderburn/src/ext_homomorphisms.jl:57 [inlined]
 [3] SymbolicWedderburn.CachedExtensionHomomorphism(::Type{Int16}, G::PermGroup{Perm{UInt16}, …}, action::OnLetters, basis::Vector{Word{Symbol}}; precompute::Bool)
   @ SymbolicWedderburn ~/.julia/dev/SymbolicWedderburn/src/ext_homomorphisms.jl:87
 [4] SymbolicWedderburn.CachedExtensionHomomorphism(::Type{Int16}, G::PermGroup{Perm{UInt16}, …}, action::OnLetters, basis::Vector{Word{Symbol}})
   @ SymbolicWedderburn ~/.julia/dev/SymbolicWedderburn/src/ext_homomorphisms.jl:80
 [5] top-level scope
   @ REPL[42]:1
```

After:
```julia
julia> ehom = SymbolicWedderburn.CachedExtensionHomomorphism(Int32, G,action,words);

julia> SW.induce(ehom, one(G))
()

julia> typeof(ans)
Perm{Int32}

```

CC: @laurentbartholdi