### PR TITLE
double the quaternionic characters in affordable_real

### DIFF
--- a/examples/ex_SL(2,3).jl
+++ b/examples/ex_SL(2,3).jl
@@ -13,7 +13,7 @@ MyGroup = PermGroup([gen1, gen2, gen3]) # SL(2,3)
 tbl = SW.CharacterTable(Rational{Int}, MyGroup)
 
 # Get irreducible characters
-irreducible_chars = irreducible_characters(tbl)
+irreducible_chars = SW.irreducible_characters(tbl)
 
 # Define multiplicities (for simplicity, use ones)
 multiplicities = fill(1, length(irreducible_chars))

--- a/examples/ex_SL(2,3).jl
+++ b/examples/ex_SL(2,3).jl
@@ -1,0 +1,35 @@
+using SymbolicWedderburn
+using PermutationGroups
+import SymbolicWedderburn as SW
+
+
+# Constructing SL(2,3) or binary tetrahedral group as a permutation group of 8 elements
+gen1 = perm"(1,2,3,4)(5,6,7,8)" 
+gen2 = perm"(1,7,3,5)(2,6,4,8)"
+gen3 = perm"(2,6,7)(4,8,5)"  
+MyGroup = PermGroup([gen1, gen2, gen3]) # SL(2,3)
+
+# Compute the character table
+tbl = SW.CharacterTable(Rational{Int}, MyGroup)
+
+# Get irreducible characters
+irreducible_chars = irreducible_characters(tbl)
+
+# Define multiplicities (for simplicity, use ones)
+multiplicities = fill(1, length(irreducible_chars))
+
+# Get real irreducible characters and their multiplicities
+real_irreps, real_mults = SW.affordable_real(irreducible_chars, multiplicities)
+# Print the Frobinus-Schur indicator of each complex irrep
+using SymbolicWedderburn.Characters
+for (i, χ) in enumerate(irreducible_characters(tbl))
+    fs_indicator = Characters.frobenius_schur(χ)
+    println("Frobenius-Schur indicator of $χ: $fs_indicator")
+    println()
+end
+# Print characters of real irreps
+println("Real Irreducible Characters:")
+for irrep in real_irreps
+    println(irrep)
+end
+# Expected Result: χ does not change if its FS is 1. χ is doubled if its FS is -1. χ is added by another character if its FS is 0.

--- a/examples/ex_SL(2,3).jl
+++ b/examples/ex_SL(2,3).jl
@@ -15,8 +15,8 @@ tbl = SW.CharacterTable(Rational{Int}, MyGroup)
 # Get irreducible characters
 irreducible_chars = SW.irreducible_characters(tbl)
 
-# Define multiplicities (for simplicity, use ones)
-multiplicities = fill(1, length(irreducible_chars))
+# Define multiplicities (for simplicity, use twos, it should be even for quaternion-type irreps)
+multiplicities = fill(2, length(irreducible_chars))
 
 # Get real irreducible characters and their multiplicities
 real_irreps, real_mults = SW.affordable_real(irreducible_chars, multiplicities)

--- a/src/sa_basis.jl
+++ b/src/sa_basis.jl
@@ -6,10 +6,14 @@ function affordable_real(
     mls_real = similar(multiplicities, 0)
     for (i, χ) in pairs(irreducible_characters)
         ι = Characters.frobenius_schur(χ)
-        if abs(ι) == 1 # real or quaternionic
-            @debug "real/quaternionic:" χ
+        if ι == 1 # real
+            @debug "real" χ
             push!(irr_real, χ)
             push!(mls_real, multiplicities[i])
+        elseif ι == -1 # quaternion
+            @debug "quaterionic" χ
+            push!(irr_real, 2*χ)
+            push!(mls_real, multiplicities[i]/2)
         else # complex one...
             cχ = conj(χ)
             k = findfirst(==(cχ), irreducible_characters)


### PR DESCRIPTION
Adding example that contains tall three possibilities(real, complex, and quaternion-type)
Distinguishing the constructions of characters for real-type and quaternion-type irreps