### PR TITLE
Fix precompile script for Julia v1.12

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,50 +1,34 @@
 import PrecompileTools
 
+struct _Word{T}
+    alphabet::Vector{T}
+    letters::Vector{Int}
+end
+
+function Base.:(==)(w::_Word, v::_Word)
+    return w.alphabet == v.alphabet && w.letters == v.letters
+end
+
+function Base.hash(w::_Word, h::UInt = UInt(0))
+    return hash(w.alphabet, hash(w.letters, hash(_Word, h)))
+end
+
+struct _OnLetters <: ByPermutations end
+
+function action(::_OnLetters, p::AP.AbstractPermutation, w::_Word)
+    return _Word(w.alphabet, [l^p for l in w.letters])
+end
+
 PrecompileTools.@setup_workload begin
-    struct Word{T}
-        alphabet::Vector{T}
-        letters::Vector{Int}
-
-        function Word(
-            a::AbstractVector{T},
-            l::AbstractVector{<:Integer},
-        ) where {T}
-            all(i -> 1 <= i <= length(a), l) ||
-                throw(ArgumentError("Invalid word over alphabet $a: $l"))
-            return new{T}(a, l)
-        end
+    A = [:a, :b, :c]
+    words = [_Word(A, [i]) for i in 1:3]
+    for r in 2:4
+        append!(
+            words,
+            [_Word(A, collect(w)) for w in Iterators.product(fill(1:3, r)...)],
+        )
     end
-    Base.show(io::IO, w::Word) = join(io, w.alphabet[w.letters], "·")
-
-    function Base.:(==)(w::Word, v::Word)
-        return w.alphabet == v.alphabet && w.letters == v.letters
-    end
-    function Base.hash(w::Word, h::UInt = UInt(0))
-        return hash(w.alphabet, hash(w.letters, hash(Word, h)))
-    end
-
-    struct OnLetters <: ByPermutations end
-    function action(::OnLetters, p::AP.AbstractPermutation, w::Word)
-        return Word(w.alphabet, [w.letters[i]^p for i in eachindex(w.letters)])
-    end
-
-    function allwords(A, radius)
-        words = [Word(A, [i]) for i in 1:length(A)]
-        for r in 2:radius
-            append!(
-                words,
-                [
-                    Word(A, collect(w)) for
-                    w in Iterators.product(fill(1:3, r)...)
-                ],
-            )
-        end
-        return words
-    end
-
-    words = allwords([:a, :b, :c], 4)
-    act = OnLetters()
-
+    act = _OnLetters()
     PrecompileTools.@compile_workload begin
         G = PG.PermGroup(PG.perm"(1,2,3)", PG.perm"(1,2)")
         wd = WedderburnDecomposition(Rational{Int}, G, act, words, words)


### PR DESCRIPTION
It's pretty weird to define new methods and structs here just for the purpose of precompile. I can see why it broke upstream.

You can also trim out a lot of the cruft. We don't need `show` or `ArgumentError` defined for the precompile?

Closes https://github.com/kalmarek/SymbolicWedderburn.jl/issues/97